### PR TITLE
Creates workflow to update the issue status column in a project based…

### DIFF
--- a/.github/workflows/update-pr-issue-status.yml
+++ b/.github/workflows/update-pr-issue-status.yml
@@ -32,17 +32,17 @@ jobs:
             const projectId = 4;
             const columnName = "In Review";
 
-            const { data: project } = await github.projects.get({
+            const { data: project } = await github.rest.projects.get({
               project_id: projectId
             });
 
-            const column = project.columns.find(col => col.name === columnName);
+            const column = project.rest.columns.find(col => col.name === columnName);
 
             if (!column) {
               throw new Error(`Column "${columnName}" not found in project.`);
             }
 
-            await github.projects.moveCard({
+            await github.rest.projects.moveCard({
               card_id: issueNumber,
               position: 'top',
               column_id: column.id


### PR DESCRIPTION
# Summary
An attempt to add a Workflow to our repo that updates an Issues' status when it is linked to a PR. This is part reading GitHub documentation and part ChatGPT research. Meaning...this is my first attempt at a workflow!

Will need to also add this workflow to the Node repo if it works here.

## Testing Instructions

- I believe if this looks okay, it can be merged and then tested. I am curious if it is going to move the issue to the right column considering there are multiple views in the board 🤔 

CC: @nathan-schmidt-viget @nick-telsan 