### PR TITLE
VS Code settings and extensions recommendations

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+	"recommendations": ["valeryanm.vscode-phpsab", "EditorConfig.EditorConfig"]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,15 @@
+{
+	"editor.indentSize": "tabSize",
+	"editor.tabSize": 4,
+	"editor.formatOnSave": true,
+	"phpsab.debug": true,
+	"intelephense.environment.phpVersion": "8.1",
+	"phpsab.allowedAutoRulesets": [
+		".phpcs.xml",
+		".phpcs.xml.dist",
+		"phpcs.xml",
+		"phpcs.xml.dist",
+		"phpcs.ruleset.xml",
+		"ruleset.xml"
+	]
+}


### PR DESCRIPTION
# Summary

This adds some VS Code setting and extension recommendations. One of which is `EditorConfig.EditorConfig` which forces VS code to use the setting in the `.editorconfig` file. So the `settings.json` is a bit of a fall but just in case they don't use/have that extension. 

## Issues
NA

CC @bd-viget 