### PR TITLE
Homepage template

### DIFF
--- a/themes/goodbids-nonprofit/functions.php
+++ b/themes/goodbids-nonprofit/functions.php
@@ -4,24 +4,15 @@
  *
  * @package GoodBids_Nonprofit
  *
- * @since 1.0
+ * @since 1.0.0
  */
 
- /**
+/**
  * Load Theme Assets
- *
- * @package GoodBids_Nonprofit
- *
- * @since 1.0
  */
- require_once get_stylesheet_directory() . '/inc/assets.php';
-
+require_once get_stylesheet_directory() . '/inc/assets.php';
 
 /**
  * Load Theme Patterns
- *
- * @package GoodBids_Nonprofit
- *
- * @since 1.0
  */
- require_once get_stylesheet_directory() . '/inc/patterns.php';
+require_once get_stylesheet_directory() . '/inc/patterns.php';

--- a/themes/goodbids-nonprofit/inc/patterns.php
+++ b/themes/goodbids-nonprofit/inc/patterns.php
@@ -4,21 +4,21 @@
  *
  * @package GoodBids_Nonprofit
  *
- * @since 1.0
+ * @since 1.0.0
  */
 
 /**
  * Register Component Pattern Category
  *
- * @since 1.0
+ * @since 1.0.0
  */
 add_action(
 	'init',
-	function() {
+	function () {
 		register_block_pattern_category(
 			'goodBids-nonprofit',
 			[
-				'label' => __( 'GoodBids Non-profit', 'goodbids-nonprofit' ),
+				'label' => __( 'GoodBids Nonprofit', 'goodbids-nonprofit' ),
 			]
 		);
 	}
@@ -27,21 +27,21 @@ add_action(
 /**
  * Register Patterns
  *
- * @since 1.0
+ * @since 1.0.0
  */
 add_action(
 	'init',
-	function() {
+	function () {
 		$patterns = [
 			[
-				'name'        	=> 'template-home-nonprofit',
-				'path'        	=> 'patterns/template-home-nonprofit.php',
-				'title'       	=> __( 'Non-profit Home Template', 'goodbids-nonprofit' ),
-				'description' 	=> _x( 'Template for the Non-profit Homepage', 'Block pattern description', 'goodbids-nonprofit' ),
-				'categories' 	=> ['featured', 'goodBids-nonprofit'],
-				'keywords'    	=> ['home', 'non-profit', 'template', 'page'],
-				'templateTypes' => ['front-page', 'home', 'page'],
-			]
+				'name'          => 'template-home-nonprofit',
+				'path'          => 'patterns/template-home-nonprofit.php',
+				'title'         => __( 'Nonprofit Home Template', 'goodbids-nonprofit' ),
+				'description'   => _x( 'Template for the Nonprofit Homepage', 'Block pattern description', 'goodbids-nonprofit' ),
+				'categories'    => [ 'featured', 'goodBids-nonprofit' ],
+				'keywords'      => [ 'home', 'non-profit', 'template', 'page' ],
+				'templateTypes' => [ 'front-page', 'home', 'page' ],
+			],
 		];
 
 		foreach ( $patterns as $pattern ) {
@@ -57,7 +57,7 @@ add_action(
 				include $path;
 				$content = ob_get_clean();
 			} else {
-				$content = file_get_contents( $path );
+				$content = wpcom_vip_file_get_contents( $path );
 			}
 
 			$pattern['content'] = $content;

--- a/themes/goodbids-nonprofit/patterns/template-home-nonprofit.php
+++ b/themes/goodbids-nonprofit/patterns/template-home-nonprofit.php
@@ -1,9 +1,5 @@
-<!-- wp:template-part {"slug":"header","area":"header","tagName":"header"} /-->
-
 <!-- wp:group {"tagName":"main","style":{"spacing":{"blockGap":"0","margin":{"top":"0"}}},"layout":{"type":"default"}} -->
 <main class="wp-block-group" style="margin-top:0">
 	<!-- wp:pattern {"slug":"twentytwentyfour/page-home-business"} /-->
 </main>
 <!-- /wp:group -->
-
-<!-- wp:template-part {"slug":"footer","area":"footer","tagName":"footer"} /-->

--- a/themes/goodbids-nonprofit/style.css
+++ b/themes/goodbids-nonprofit/style.css
@@ -1,9 +1,9 @@
 /*
-Theme Name: GoodBids Non-profit
+Theme Name: GoodBids Nonprofit
 Theme URI: https://goodbids.org
 Author: Viget
 Author URI: https://viget.com
-Description: Twenty Twenty-Four child theme for GoodBids Non-profit sites.
+Description: Twenty Twenty-Four child theme for GoodBids Nonprofit sites.
 Version: 1.0
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/themes/goodbids-nonprofit/templates/front-page.html
+++ b/themes/goodbids-nonprofit/templates/front-page.html
@@ -1,1 +1,3 @@
-<!-- wp:pattern {"slug":"goodbids-nonprofit/template-home-nonprofit"} /-->
+<!-- wp:template-part {"slug":"header","area":"header","tagName":"header"} /-->
+	<!-- wp:pattern {"slug":"goodbids-nonprofit/template-home-nonprofit"} /-->
+<!-- wp:template-part {"slug":"footer","area":"footer","tagName":"footer"} /-->

--- a/themes/goodbids-nonprofit/templates/page.html
+++ b/themes/goodbids-nonprofit/templates/page.html
@@ -1,0 +1,1 @@
+<!-- wp:pattern {"slug":"goodbids-nonprofit/template-page-nonprofit"} /-->


### PR DESCRIPTION
# Summary

This setups a homepage template for non-profit sites. This template is the default for the front page once the site is changed to use a static page (that will be in another PR). 
Right now I am pulling a generic pattern into the template, but once the homepage is set up in the WP admin that will be replaced with the new layout. 

This PR also set up the `goodBids-nonprofit` pattern category and an easy way to add new patterns in the future. 

## Issues

* #8 

## Testing Instructions

- Create a new site: Sites -> Add New Site
- Go to that new site and active the GoodBid Theme (if this [PR](https://github.com/Good-Bids/goodbids/pull/60) is not merged yet)
- Go to Appearance -> Editor -> Patterns and make sure we have a `GoodBids Non-profit` category. 
- Then go to Appearance -> Editor -> Pages -> Front Page and make sure it looks like the screenshot and you can edit it

## Screenshots

| Patterns | Pages -> Front Page | Edit Front Page |
|--------|--------|--------|
| ![Screenshot 2023-12-11 at 10 02 09 AM](https://github.com/Good-Bids/goodbids/assets/91974372/3383d682-5f58-4d21-9d56-8bb76186e286)| ![Screenshot 2023-12-11 at 10 12 03 AM](https://github.com/Good-Bids/goodbids/assets/91974372/4e0cb831-f071-4fdb-b64d-2e2d5262b106) | ![Screenshot 2023-12-11 at 10 12 18 AM](https://github.com/Good-Bids/goodbids/assets/91974372/04819fe0-a975-4d80-b71c-dd6bc11ea78f) | 


Review cc @ten1seven
