### PR TITLE
Remove Cookie Law Info plugin

### DIFF
--- a/client-mu-plugins/goodbids/composer.json
+++ b/client-mu-plugins/goodbids/composer.json
@@ -51,7 +51,6 @@
 		"oomphinc/composer-installers-extender": "^2.0",
 		"vlucas/phpdotenv": "^5.5",
 		"wpackagist-plugin/accessibility-checker": "^1.6",
-		"wpackagist-plugin/cookie-law-info": "^3.1",
 		"wpackagist-plugin/svg-support": "^2.5",
 		"wpackagist-plugin/user-switching": "^1.7",
 		"wpackagist-plugin/woocommerce": "^8.4",

--- a/client-mu-plugins/goodbids/composer.lock
+++ b/client-mu-plugins/goodbids/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2a0087aeafc8bec91cc89a2956f8ada9",
+    "content-hash": "dcd86d96e7ccf5087eb8265a5f1ae291",
     "packages": [
         {
             "name": "composer/installers",
@@ -742,24 +742,6 @@
             },
             "type": "wordpress-plugin",
             "homepage": "https://wordpress.org/plugins/accessibility-checker/"
-        },
-        {
-            "name": "wpackagist-plugin/cookie-law-info",
-            "version": "3.1.7",
-            "source": {
-                "type": "svn",
-                "url": "https://plugins.svn.wordpress.org/cookie-law-info/",
-                "reference": "tags/3.1.7"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/cookie-law-info.3.1.7.zip"
-            },
-            "require": {
-                "composer/installers": "^1.0 || ^2.0"
-            },
-            "type": "wordpress-plugin",
-            "homepage": "https://wordpress.org/plugins/cookie-law-info/"
         },
         {
             "name": "wpackagist-plugin/svg-support",

--- a/client-mu-plugins/goodbids/config.json
+++ b/client-mu-plugins/goodbids/config.json
@@ -6,7 +6,6 @@
 		"woocommerce-gateway-stripe",
 		"accessibility-checker",
 		"svg-support",
-		"cookie-law-info",
 		"user-switching"
 	]
 }


### PR DESCRIPTION
# Summary

This PR removes the Cookie Law Info plugin, to be replaced later with OneTrust.

## Issues

* #79 

## Testing Instructions

1. Visit Main GoodBids site (or any Nonprofit site) WP Admin
2. Go to Plugins
3. Make sure Cookie Law Info is not listed
4. Make sure the front-end of the site loads without any errors.
