### PR TITLE
[#39] Fixing the logic on the auction featured image

### DIFF
--- a/client-mu-plugins/goodbids/src/classes/Auctions/Auctions.php
+++ b/client-mu-plugins/goodbids/src/classes/Auctions/Auctions.php
@@ -950,6 +950,12 @@ class Auctions {
 					return $html;
 				}
 
+				// If the auction has a featured image
+				if ( has_post_thumbnail( $post_id ) ) {
+					return $html;
+				}
+
+				// Default to the WooCommerce featured image or WooCommerce default image
 				$reward_id = $this->get_reward_product_id( $post_id );
 				$product   = wc_get_product( $reward_id );
 


### PR DESCRIPTION
# Summary

@shascher noticed we were not pulling in the auction featured image before the reward feature image. This adds that logic in before we default to the reward image and WooCommerce default image. 

## Issues

* #39 

## Testing Instructions

- Go to an auction page and add a featured image.
- Go to another auction page and make sure it does not have a featured image, but the reward product that it is linked to does have a featured image. 
- Go to a third auction page and make sure it does not have a featured image and the reward product does not have featured image. 
- Then go to the auction index `/auctions` and make sure it is pulling in like: 

> Auction Image - Use the featured image for the Auction if it's set. Otherwise, use the Main Product Image for the Prize Product associated with the Auction. If no Main Product Image is set on the Prize Product, WooCommerce will serve up a fallback.

## Screenshots

<img width="1337" alt="Screenshot 2023-12-21 at 10 18 31 AM" src="https://github.com/Good-Bids/goodbids/assets/91974372/d20106e5-e868-462b-9632-970b27ca7b03">

