### PR TITLE
[#29] WooCommerce Shipping Plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ node_modules
 /plugins/user-switching/
 /plugins/woocommerce/
 /plugins/woocommerce-gateway-stripe/
+/plugins/woocommerce-services/
 
 # Uploads directory
 /uploads/

--- a/client-mu-plugins/goodbids/composer.json
+++ b/client-mu-plugins/goodbids/composer.json
@@ -51,11 +51,12 @@
 		"illuminate/collections": "^10.38",
 		"oomphinc/composer-installers-extender": "^2.0",
 		"vlucas/phpdotenv": "^5.5",
-		"wpackagist-plugin/accessibility-checker": "^1.6",
+		"wpackagist-plugin/accessibility-checker": "^1.7",
 		"wpackagist-plugin/svg-support": "^2.5",
 		"wpackagist-plugin/user-switching": "^1.7",
 		"wpackagist-plugin/woocommerce": "^8.4",
-		"wpackagist-plugin/woocommerce-gateway-stripe": "^7.7",
+		"wpackagist-plugin/woocommerce-gateway-stripe": "^7.8",
+		"wpackagist-plugin/woocommerce-services": "^2.4",
 		"wpengine/advanced-custom-fields-pro": "*"
 	},
 	"require-dev": {

--- a/client-mu-plugins/goodbids/composer.lock
+++ b/client-mu-plugins/goodbids/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d494006c8f40bed2d1fdbc56666e2f0b",
+    "content-hash": "28b8208c770388009f02a80e6523ad5a",
     "packages": [
         {
             "name": "composer/installers",
@@ -1026,15 +1026,15 @@
         },
         {
             "name": "wpackagist-plugin/accessibility-checker",
-            "version": "1.6.10",
+            "version": "1.7.0",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/accessibility-checker/",
-                "reference": "tags/1.6.10"
+                "reference": "tags/1.7.0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/accessibility-checker.1.6.10.zip"
+                "url": "https://downloads.wordpress.org/plugin/accessibility-checker.1.7.0.zip"
             },
             "require": {
                 "composer/installers": "^1.0 || ^2.0"
@@ -1098,21 +1098,39 @@
         },
         {
             "name": "wpackagist-plugin/woocommerce-gateway-stripe",
-            "version": "7.7.0",
+            "version": "7.8.0",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/woocommerce-gateway-stripe/",
-                "reference": "tags/7.7.0"
+                "reference": "tags/7.8.0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/woocommerce-gateway-stripe.7.7.0.zip"
+                "url": "https://downloads.wordpress.org/plugin/woocommerce-gateway-stripe.7.8.0.zip"
             },
             "require": {
                 "composer/installers": "^1.0 || ^2.0"
             },
             "type": "wordpress-plugin",
             "homepage": "https://wordpress.org/plugins/woocommerce-gateway-stripe/"
+        },
+        {
+            "name": "wpackagist-plugin/woocommerce-services",
+            "version": "2.4.2",
+            "source": {
+                "type": "svn",
+                "url": "https://plugins.svn.wordpress.org/woocommerce-services/",
+                "reference": "tags/2.4.2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://downloads.wordpress.org/plugin/woocommerce-services.2.4.2.zip"
+            },
+            "require": {
+                "composer/installers": "^1.0 || ^2.0"
+            },
+            "type": "wordpress-plugin",
+            "homepage": "https://wordpress.org/plugins/woocommerce-services/"
         },
         {
             "name": "wpengine/advanced-custom-fields-pro",

--- a/client-mu-plugins/goodbids/config.json
+++ b/client-mu-plugins/goodbids/config.json
@@ -4,6 +4,7 @@
 		"advanced-custom-fields-pro/acf.php",
 		"woocommerce",
 		"woocommerce-gateway-stripe",
+		"woocommerce-services",
 		"accessibility-checker",
 		"svg-support",
 		"user-switching"


### PR DESCRIPTION
# Summary

This PR adds the WooCommerce Shipping (Services) plugin to Composer. It also updates the Accessibility Checker and WooCommerce Gateway Stripe plugins to their latest versions.

## Issues

* #29 

## Testing Instructions

1. Visit the WordPress Admin for a GoodBids site
2. You should see the following banner to set up WooCommerce Shipping & Tax:
<img width="1093" alt="Screenshot 2023-12-27 at 1 27 29 PM" src="https://github.com/Good-Bids/goodbids/assets/122309362/2f2eccdf-76af-41eb-a468-65e0f8ae1f98">

## Screenshots

<img width="1096" alt="Screenshot 2023-12-27 at 1 26 37 PM" src="https://github.com/Good-Bids/goodbids/assets/122309362/50b6c3e3-02e6-4ce7-b769-f80bdf52d3b8">
