### PR TITLE
[#143] Setting up all auctions block

### DIFF
--- a/client-mu-plugins/goodbids/blocks/all-auctions/block.json
+++ b/client-mu-plugins/goodbids/blocks/all-auctions/block.json
@@ -1,15 +1,15 @@
 {
-  "name": "all-auction",
-  "title": "All Auctions",
-  "description": "Displays the All GoodBids Auction.",
-  "icon": "awards",
-  "category": "goodbids",
-  "textdomain": "goodbids",
-  "keywords": ["custom", "stats", "auction"],
-  "acf": {
-    "mode": "preview"
-  },
-  "supports": {
-    "jsx": false
-  }
+	"name": "all-auctions",
+	"title": "All Auctions",
+	"description": "Displays all GoodBids Auctions.",
+	"icon": "awards",
+	"category": "goodbids",
+	"textdomain": "goodbids",
+	"keywords": ["all auctions", "auctions", "listing", "archive", "index"],
+	"acf": {
+		"mode": "preview"
+	},
+	"supports": {
+		"jsx": false
+	}
 }

--- a/client-mu-plugins/goodbids/blocks/all-auctions/block.php
+++ b/client-mu-plugins/goodbids/blocks/all-auctions/block.php
@@ -10,6 +10,7 @@
 namespace GoodBids\Blocks;
 
 use GoodBids\Plugins\ACF\ACFBlock;
+use Illuminate\Support\Collection;
 
 /**
  * Class for All Auctions Block
@@ -19,44 +20,55 @@ use GoodBids\Plugins\ACF\ACFBlock;
 class AllAuctions extends ACFBlock {
 
 	/**
-	 * Returns an array of all active auctions
+	 * Returns an array of all active auctions across all sites
 	 *
 	 * @since 1.0.0
 	 *
 	 * @return array
 	 */
-	public function get_all_auctions(): array {
-		$all_auctions = [];
-		foreach ( get_sites() as $nonprofit ) {
-			$nonprofit_id = get_object_vars( $nonprofit )['blog_id'];
-
-			$all_auctions[] = $this->get_site_auctions( $nonprofit_id );
-		}
-
-		return array_filter( array_merge( ...$all_auctions ) );
+	public function get_all_site_auctions(): array {
+		return Collection::make( get_sites() )
+			->flatMap(
+				function ( $site ) {
+					$site_id = get_object_vars( $site )['blog_id'];
+					return $this->get_site_auctions( $site_id );
+				}
+			)
+			->filter()
+			->all();
 	}
 
 	/**
-	 * Returns an array of all active auctions
+	 * Returns an array of all active auctions for a given site
 	 *
 	 * @since 1.0.0
 	 *
-	 * @return mixed
+	 * @param int $site_id
+	 *
+	 * @return array
 	 */
-	private function get_site_auctions( $nonprofit_id ): mixed {
-		$args = [
-			'post_type' => 'gb-auction',
+	private function get_site_auctions( int $site_id ): array {
+		// Start by switching to blog and get all auctions
+		switch_to_blog( $site_id );
+		$args     = [
+			'post_type'      => goodbids()->auctions->get_post_type(),
+			'post_status'    => 'publish',
+			'posts_per_page' => -1,
+			'fields'         => 'ids',
 		];
-
-		switch_to_blog( $nonprofit_id );
-		$auctions = get_posts( $args );
-		foreach ( $auctions as $auction ) {
-			if ( has_post_thumbnail( $auction->ID ) ) {
-				$auction->img = get_the_post_thumbnail( $auction->ID, 'woocommerce_thumbnail' );
-			}
-		}
+		$auctions = new \WP_Query( $args );
 		restore_current_blog();
 
-		return $auctions;
+		if ( ! $auctions->have_posts() ) {
+			return [];
+		}
+		return collect( $auctions->posts )->map(
+			function ( $post_id ) use ( $site_id ) {
+				return [
+					'post_id' => $post_id,
+					'site_id' => $site_id,
+				];
+			}
+		)->all();
 	}
 }

--- a/client-mu-plugins/goodbids/blocks/all-auctions/render.php
+++ b/client-mu-plugins/goodbids/blocks/all-auctions/render.php
@@ -8,25 +8,47 @@
  * @package GoodBids
  */
 
-$all_auction = new GoodBids\Blocks\AllAuctions( $block );
+$all_auctions = new GoodBids\Blocks\AllAuctions( $block );
+$auctions     = $all_auctions->get_all_site_auctions();
+
+if ( ! count( $auctions ) ) :
+	if ( is_admin() ) :
+		printf(
+			'<p>%s</p>',
+			esc_html__( 'No auctions found.', 'goodbids' )
+		);
+	endif;
+
+	return;
+endif;
+
+global $post;
+$og_post = $post;
 ?>
 
 <section <?php block_attr( $block ); ?>>
 	<ul class="grid grid-cols-1 gap-8 list-none lg:grid-cols-3 sm:grid-cols-2">
-		<?php foreach ( $all_auction->get_all_auctions() as $auction ) : ?>
-		<li>
-			<a href="<?php echo esc_url( $auction->guid ); ?>" class="block">
-				<?php if ( $auction->img ) : ?>
-					<figure class="wp-block-post-featured-image aspect-square *:w-full *:h-full">
-						<?php echo wp_kses_post( $auction->img ); ?>
-					</figure>
-				<?php endif; ?>
-
-				<h2 class="wp-block-post-title has-large-font-size">
-					<?php esc_html_e( $auction->post_title ); ?>
-				</h2>
-			</a>
-		</li>
-		<?php endforeach; ?>
+		<?php
+		foreach ( $auctions as $auction ) :
+			switch_to_blog( $auction['site_id'] );
+			$post = get_post( $auction['post_id'] ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+			?>
+			<li>
+				<a href="<?php echo is_admin() ? '#' : get_the_permalink(); ?>" class="block">
+				<?php if ( has_post_thumbnail() ) : ?>
+						<figure class="wp-block-post-featured-image aspect-square *:w-full *:h-full">
+							<?php the_post_thumbnail( 'woocommerce_thumbnail' ); ?>
+						</figure>
+					<?php endif; ?>
+					<h2 class="wp-block-post-title has-large-font-size">
+						<?php the_title(); ?>
+					</h2>
+				</a>
+			</li>
+			<?php
+			restore_current_blog();
+		endforeach;
+		$post = $og_post; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		?>
 	</ul>
 </section>

--- a/client-mu-plugins/goodbids/blocks/auction-metrics-general/block.json
+++ b/client-mu-plugins/goodbids/blocks/auction-metrics-general/block.json
@@ -1,15 +1,15 @@
 {
-  "name": "auction-metrics-general",
-  "title": "Auction Metrics (General)",
-  "description": "Displays the general Auction metrics.",
-  "icon": "awards",
-  "category": "goodbids",
-  "textdomain": "goodbids",
-  "keywords": ["custom", "details", "stats", "auction"],
-  "acf": {
-    "mode": "preview"
-  },
-  "supports": {
-    "jsx": false
-  }
+	"name": "auction-metrics-general",
+	"title": "Auction Metrics (General)",
+	"description": "Displays the general Auction metrics.",
+	"icon": "awards",
+	"category": "goodbids",
+	"textdomain": "goodbids",
+	"keywords": ["custom", "details", "stats", "auction"],
+	"acf": {
+		"mode": "preview"
+	},
+	"supports": {
+		"jsx": false
+	}
 }


### PR DESCRIPTION
# Summary

This is a "See It work" to test an implementation of getting all auctions from all nonprofit sites. It creates a new block that pull in an array of all the posts from all the nonprofit site. This is by no means a final version and the method of getting the auctions may need to be update/refactored to be more efficient. 

One thing, that I spend sometime on but could not figure out a good solutions, is getting the product image from the Auction page. I have it currently set to pull the Auction image but not the linked product image. We my need to update the `set_default_feature_image` [function](https://github.com/Good-Bids/goodbids/blob/b97d92fae64e56493a9be3edb90cf8cbaa04ccc3/client-mu-plugins/goodbids/src/classes/Auctions/Auctions.php#L945). 

## Issues

* #143

## Testing Instructions

- Go to a site page and add a new block, add the block All Auctions. 
- This will add the new All Auctions block to the page. 
- Go to any other nonprofit site and add a new auction. 
- Go back to your page with the All Auctions block and make sure your new auction has been added. 

## Screenshots

<img width="1375" alt="Screenshot 2024-01-04 at 3 50 03 PM" src="https://github.com/Good-Bids/goodbids/assets/91974372/1be84ea7-9b6f-4ff5-baba-58cb7ec53f75">

