### PR TITLE
[#97] Free Bids

### DIFF
--- a/client-mu-plugins/goodbids/src/blocks/bidding/client.tsx
+++ b/client-mu-plugins/goodbids/src/blocks/bidding/client.tsx
@@ -1,4 +1,0 @@
-import React from 'react';
-import { render } from '@wordpress/element';
-
-render(<h1>Hello World</h1>, document.getElementById('goodbids-bidding'));

--- a/client-mu-plugins/goodbids/src/blocks/bidding/components/bid-button.tsx
+++ b/client-mu-plugins/goodbids/src/blocks/bidding/components/bid-button.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import clsx from 'clsx';
 import { initialState } from '../utils/get-initial-state';
+import { DEMO_DATA } from '../utils/demo-data';
 
 export function BidButton() {
 	const disabled =
-		initialState.lastBidder === 'fake-user' &&
+		initialState.lastBidder === DEMO_DATA.userId &&
 		new Date(initialState.endTime) > new Date();
 
 	const classes = clsx(
@@ -20,7 +21,7 @@ export function BidButton() {
 	}
 
 	if (new Date(initialState.endTime) < new Date()) {
-		if (initialState.lastBidder === 'fake-user') {
+		if (initialState.lastBidder === DEMO_DATA.userId) {
 			return (
 				<a href={initialState.prizeUrl} className={classes}>
 					Claim Your Reward

--- a/client-mu-plugins/goodbids/src/blocks/bidding/components/countdown-timer.tsx
+++ b/client-mu-plugins/goodbids/src/blocks/bidding/components/countdown-timer.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { ClockIcon } from './clock-icon';
 import { initialState } from '../utils/get-initial-state';
+import { DEMO_DATA } from '../utils/demo-data';
 
 type TimeStatus = 'not-started' | 'in-progress' | 'ended';
 
@@ -139,7 +140,7 @@ export function CountdownTimer() {
 			<ClockIcon />
 
 			{getTimeRemaining(
-				'no-user',
+				DEMO_DATA.userId,
 				initialState.lastBidder,
 				timeRemaining,
 				initialState.userBids,

--- a/client-mu-plugins/goodbids/src/blocks/bidding/components/driver.tsx
+++ b/client-mu-plugins/goodbids/src/blocks/bidding/components/driver.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { getInitialState } from '../utils/get-initial-state';
 import { BidButton } from './bid-button';
 import { CountdownTimer } from './countdown-timer';
+import { FreeBidButton } from './free-bid-button';
 import { Metrics } from './metrics';
 
 export function Driver() {
@@ -18,6 +19,7 @@ export function Driver() {
 			/>
 			<CountdownTimer />
 			<BidButton />
+			<FreeBidButton />
 		</div>
 	);
 }

--- a/client-mu-plugins/goodbids/src/blocks/bidding/components/free-bid-button.tsx
+++ b/client-mu-plugins/goodbids/src/blocks/bidding/components/free-bid-button.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import clsx from 'clsx';
+import { initialState } from '../utils/get-initial-state';
+import { DEMO_DATA } from '../utils/demo-data';
+
+export function FreeBidButton() {
+	const disabled =
+		initialState.lastBidder === DEMO_DATA.userId && !DEMO_DATA.freeBids;
+
+	const classes = clsx(
+		'bg-base rounded py-2 w-full block text-center no-underline text-lg',
+		{
+			'pointer-events-none cursor-not-allowed': disabled,
+			'pointer-events-auto': !disabled,
+		},
+	);
+
+	if (
+		new Date(initialState.startTime) > new Date() ||
+		new Date(initialState.endTime) < new Date()
+	) {
+		return null;
+	}
+
+	if (initialState.freeBids) {
+		return (
+			<a href={initialState.freeBidUrl} className={classes}>
+				{`Place free bid ${
+					DEMO_DATA.freeBids
+						? `(${DEMO_DATA.freeBids} available)`
+						: ''
+				}`}
+			</a>
+		);
+	}
+
+	return null;
+}

--- a/client-mu-plugins/goodbids/src/blocks/bidding/edit.tsx
+++ b/client-mu-plugins/goodbids/src/blocks/bidding/edit.tsx
@@ -45,6 +45,9 @@ const Edit = ({ setAttributes }) => {
 			<div className="bg-base rounded text-white py-2 w-full block text-center no-underline text-lg">
 				GOODBID $0 Now
 			</div>
+			<div className="bg-base rounded text-white py-2 w-full block text-center no-underline text-lg">
+				Place free bid
+			</div>
 		</div>
 	);
 };

--- a/client-mu-plugins/goodbids/src/blocks/bidding/utils/demo-data.ts
+++ b/client-mu-plugins/goodbids/src/blocks/bidding/utils/demo-data.ts
@@ -1,0 +1,4 @@
+export const DEMO_DATA = {
+	userId: 'demo-user',
+	freeBids: 5,
+};

--- a/client-mu-plugins/goodbids/src/blocks/bidding/utils/get-initial-state.ts
+++ b/client-mu-plugins/goodbids/src/blocks/bidding/utils/get-initial-state.ts
@@ -16,6 +16,7 @@ export function getInitialState() {
 	const bidUrl = root?.getAttribute('data-bid-url');
 	const prizeUrl = root?.getAttribute('data-prize-url');
 	const nextBid = root?.getAttribute('data-next-bid');
+	const freeBidUrl = root?.getAttribute('data-free-bid-url');
 
 	return {
 		auctionId,
@@ -30,6 +31,7 @@ export function getInitialState() {
 		bidUrl: bidUrl || '',
 		prizeUrl: prizeUrl || '',
 		nextBid: nextBid ? parseInt(nextBid, 10) : 0,
+		freeBidUrl: freeBidUrl || '',
 	};
 }
 


### PR DESCRIPTION
# Summary

- Adds free bids button
- Adds demo data

## Issues

- #97

## Testing Instructions


- Start WP (`bin/start`) and Vite (`bin/start-vite`)
- Create an auction
- Visit said auction
- See the free bid button (you can even click it)

Presently timer inputs are not dynamic (coming in #140), so you will need to manually update the `data-initial` values in `client-mu-plugins/goodbids/blocks/bid-now/render.php` to see all of the states as well as the `DEMO_DATA` in `client-mu-plugins/goodbids/src/utils/demo-data.ts`.

## Screenshots

![image](https://github.com/Good-Bids/goodbids/assets/48295174/3ff34d33-d5e9-4429-b5d1-8f7e383e6d61)
