### PR TITLE
[#91] Gallery image Bug Fix

### DIFF
--- a/client-mu-plugins/goodbids/blocks/reward-product-gallery/block.css
+++ b/client-mu-plugins/goodbids/blocks/reward-product-gallery/block.css
@@ -18,6 +18,10 @@
 		@apply rounded;
 	}
 
+	.woocommerce div.product div.images .flex-control-thumbs li img {
+		@apply h-full object-cover;
+	}
+
 	.woocommerce-product-gallery.woocommerce-product-gallery--with-images.woocommerce-product-gallery--columns-4.images {
 		@apply !opacity-100;
 	}


### PR DESCRIPTION
# Summary

This fixes the auction gallery image boxes so that the images fit inside of the square. 

## Issues

* #91

## Testing Instructions

1. Go to an auction page and add a landscape/narrow image
2. Make sure the images fit the square. 

## Screenshots

| Old | Fix |
|--------|--------|
| <img width="401" alt="Screenshot 2024-01-10 at 10 22 04 AM" src="https://github.com/Good-Bids/goodbids/assets/91974372/cfbe3ef8-ca6f-4c7d-8f77-cddcd47aff9b"> |<img width="673" alt="Screenshot 2024-01-10 at 10 21 18 AM" src="https://github.com/Good-Bids/goodbids/assets/91974372/5a8aca9e-e6da-4461-9124-0940949ea0ce"> | 

