### PR TITLE
[#171] Updating login button in admin

### DIFF
--- a/client-mu-plugins/goodbids/postcss.config.js
+++ b/client-mu-plugins/goodbids/postcss.config.js
@@ -1,6 +1,7 @@
 export default {
-  plugins: {
-    tailwindcss: {},
-    autoprefixer: {},
-  },
+	plugins: {
+		'tailwindcss/nesting': {},
+		tailwindcss: {},
+		autoprefixer: {},
+	},
 };

--- a/client-mu-plugins/goodbids/src/assets/css/main.css
+++ b/client-mu-plugins/goodbids/src/assets/css/main.css
@@ -1,6 +1,7 @@
 /* Import any CSS from blocks before tailwind */
 @import '../../../blocks/reward-product-gallery/block.css';
 @import 'patterns/nonprofit-interest-form.css';
+@import 'patterns/header.css';
 
 @tailwind base;
 @tailwind components;

--- a/client-mu-plugins/goodbids/src/assets/css/patterns/header.css
+++ b/client-mu-plugins/goodbids/src/assets/css/patterns/header.css
@@ -1,0 +1,7 @@
+@layer components {
+	.wp-block-woocommerce-customer-account {
+		a {
+			@apply btn-fill py-2 px-5 !text-base-2 hover:!text-contrast focus:!text-contrast;
+		}
+	}
+}

--- a/themes/goodbids-main/parts/header.html
+++ b/themes/goodbids-main/parts/header.html
@@ -14,7 +14,7 @@
 		<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|20"}},"layout":{"type":"flex","flexWrap":"wrap"}} -->
 		<div class="wp-block-group">
 			<!-- wp:navigation {"layout":{"type":"flex","justifyContent":"right","orientation":"horizontal"},"style":{"spacing":{"margin":{"top":"0"},"blockGap":"var:preset|spacing|20"},"layout":{"selfStretch":"fit","flexSize":null}},"fontSize":"x-small"} /-->
-			<!-- wp:loginout {"className":"wp-button-custom","style":{"spacing":{"margin":{"top":"0"},"blockGap":"var:preset|spacing|20"},"layout":{"selfStretch":"fit","flexSize":null}},"textColor":"base-2","fontSize":"x-small"} /-->
+			<!-- wp:woocommerce/customer-account {"displayStyle":"text_only","iconStyle":"alt","iconClass":"wc-block-customer-account__account-icon","className":"btn","textColor":"contrast","fontSize":"x-small","style":{"layout":{"selfStretch":"fit","flexSize":null},"elements":{"link":{"color":{"text":"var:preset|color|contrast"}}}}} /-->
 		</div>
 		<!-- /wp:group -->
 	</div>

--- a/themes/goodbids-nonprofit/patterns/header-nonprofit.php
+++ b/themes/goodbids-nonprofit/patterns/header-nonprofit.php
@@ -27,8 +27,7 @@
 		<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|20"}},"layout":{"type":"flex","flexWrap":"wrap"}} -->
 		<div class="wp-block-group">
 			<!-- wp:navigation {"layout":{"type":"flex","justifyContent":"right","orientation":"horizontal"},"style":{"spacing":{"margin":{"top":"0"},"blockGap":"var:preset|spacing|20"},"layout":{"selfStretch":"fit","flexSize":null}},"fontSize":"x-small"} /-->
-			<!-- wp:loginout {"className":"wp-button-custom","style":{"spacing":{"margin":{"top":"0"},"blockGap":"var:preset|spacing|20"},"layout":{"selfStretch":"fit","flexSize":null}},"textColor":"base-2","fontSize":"x-small"} /-->
-		</div>
+			<!-- wp:woocommerce/customer-account {"displayStyle":"text_only","iconStyle":"alt","iconClass":"wc-block-customer-account__account-icon","className":"btn","textColor":"contrast","fontSize":"x-small","style":{"layout":{"selfStretch":"fit","flexSize":null},"elements":{"link":{"color":{"text":"var:preset|color|contrast"}}}}} /-->		</div>
 		<!-- /wp:group -->
 	</div>
 


### PR DESCRIPTION
# Summary

This changes the`loginout` block to `wp:woocommerce/customer-account` on the nonprofit and main theme.

- Custom style so it looks like a button. 
- `'tailwindcss/nesting'` for nested CSS 

## Issues

* #171 

## Testing Instructions

1. Make sure your navigation has not ben customized if it has reset it. 
2. Go to any page and make sure the new Login/My Account is there. 

## Screenshots
| Login | Logged In |
|--------|--------|
| <img width="291" alt="Screenshot 2024-01-10 at 2 34 38 PM" src="https://github.com/Good-Bids/goodbids/assets/91974372/b6be23b7-2c7a-4f57-8006-7273f7a1344c">  | <img width="350" alt="Screenshot 2024-01-10 at 2 33 21 PM" src="https://github.com/Good-Bids/goodbids/assets/91974372/80293151-2ba1-42d6-b2af-3f795b725e60"> | 