### PR TITLE
[#174] Adding terms and condition page pattern

### DIFF
--- a/client-mu-plugins/goodbids/src/classes/Frontend/Patterns.php
+++ b/client-mu-plugins/goodbids/src/classes/Frontend/Patterns.php
@@ -86,16 +86,15 @@ class Patterns {
 				];
 
 				$section_sidebar_chapters = [
-					'name'          => 'section-sidebar-chapters',
-					'path'          => GOODBIDS_PLUGIN_PATH . 'views/patterns/section-sidebar-chapters.php',
-					'title'         => __( 'Section with Sidebar and Chapters', 'goodbids' ),
-					'description'   => _x( 'Template for Terms and Conditions or any page with sidebar and chapters', 'Block pattern description', 'goodbids' ),
-					'categories'    => [ 'page', 'goodbids' ],
-					'keywords'      => [ 'conditions', 'terms', 'page', 'sidebar' ],
-					'postTypes'     => [ 'page', 'wp_template' ],
-					'templateTypes' => [ 'page' ],
-					'source'        => 'plugin',
-					'inserter'      => true,
+					'name'        => 'section-sidebar-chapters',
+					'path'        => GOODBIDS_PLUGIN_PATH . 'views/patterns/section-sidebar-chapters.php',
+					'title'       => __( 'Section with Sidebar and Chapters', 'goodbids' ),
+					'description' => _x( 'Template for any page with sidebar and chapters', 'Block pattern description', 'goodbids' ),
+					'categories'  => [ 'page', 'goodbids' ],
+					'keywords'    => [ 'conditions', 'terms', 'page', 'sidebar' ],
+					'postTypes'   => [ 'page' ],
+					'source'      => 'plugin',
+					'inserter'    => true,
 				];
 
 				$template_about = [
@@ -124,6 +123,19 @@ class Patterns {
 					'inserter'    => false,
 				];
 
+				$template_terms_conditions = [
+					'name'          => 'template-terms-conditions',
+					'path'          => GOODBIDS_PLUGIN_PATH . 'views/patterns/template-terms-conditions.php',
+					'title'         => __( 'Terms and Conditions', 'goodbids' ),
+					'description'   => _x( 'Template for GoodBids Terms and Conditions Page', 'Block pattern description', 'goodbids' ),
+					'categories'    => [ 'page', 'goodbids' ],
+					'keywords'      => [ 'conditions', 'terms', 'page', 'sidebar' ],
+					'postTypes'     => [ 'page', 'wp_template' ],
+					'templateTypes' => [ 'page' ],
+					'source'        => 'plugin',
+					'inserter'      => true,
+				];
+
 				$this->patterns = apply_filters(
 					'goodbids_block_patterns',
 					[
@@ -133,6 +145,7 @@ class Patterns {
 						$section_sidebar_chapters,
 						$template_about,
 						$template_auction,
+						$template_terms_conditions,
 					]
 				);
 

--- a/client-mu-plugins/goodbids/views/patterns/section-sidebar-chapters.php
+++ b/client-mu-plugins/goodbids/views/patterns/section-sidebar-chapters.php
@@ -8,108 +8,14 @@
 
 ?>
 
-<!-- wp:group {"align":"wide","layout":{"type":"constrained","justifyContent":"left"}} -->
-<div class="wp-block-group alignwide">
-	<!-- wp:post-title {"level":1,"align":"wide"} /-->
-</div>
-<!-- /wp:group -->
-
 <!-- wp:group {"align":"wide","layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignwide">
 	<!-- wp:columns {"align":"wide","style":{"spacing":{"blockGap":{"top":"0"},"margin":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|30"}}}} -->
 	<div class="wp-block-columns alignwide" style="margin-top:var(--wp--preset--spacing--50);margin-bottom:var(--wp--preset--spacing--30)">
 		<!-- wp:column -->
 		<div class="wp-block-column">
-			<!-- wp:heading -->
-			<h2 class="wp-block-heading"><?php esc_html_e( 'This Section', 'goodbids' ); ?></h2>
-			<!-- /wp:heading -->
-		</div>
-		<!-- /wp:column -->
-
-		<!-- wp:column -->
-		<div class="wp-block-column">
-			<!-- wp:heading {"level":3} -->
-			<h3 class="wp-block-heading"><?php esc_html_e( 'This Chapter', 'goodbids' ); ?></h3>
-			<!-- /wp:heading -->
-
-			<!-- wp:paragraph -->
-			<p><?php esc_html_e( 'We’re turning charity auctions and fundraising upside down and inside out.', 'goodbids' ); ?></p>
-			<!-- /wp:paragraph -->
-
-			<!-- wp:paragraph -->
-			<p><?php esc_html_e( 'A GOODBIDS positive auction has a great prize, and you can submit bids, but the big difference is that every bid is a non-refundable donation to a charity you care about.', 'goodbids' ); ?></p>
-			<!-- /wp:paragraph -->
-
-			<!-- wp:paragraph -->
-			<p><?php esc_html_e( 'That means that great prizes end up going for really low bids. And charities end up raising more money at the same time.', 'goodbids' ); ?></p>
-			<!-- /wp:paragraph -->
-
-			<!-- wp:heading {"level":3} -->
-			<h3 class="wp-block-heading"><?php esc_html_e( 'This Chapter', 'goodbids' ); ?></h3>
-			<!-- /wp:heading -->
-
-			<!-- wp:paragraph -->
-			<p><?php esc_html_e( 'All you need to do is find an auction you like and place a bid. The money goes directly to the charity and you’ll get a receipt for your tax deductible donation.', 'goodbids' ); ?></p>
-			<!-- /wp:paragraph -->
-		</div>
-		<!-- /wp:column -->
-	</div>
-	<!-- /wp:columns -->
-</div>
-<!-- /wp:group -->
-
-<!-- wp:group {"align":"wide","layout":{"type":"constrained"}} -->
-<div class="wp-block-group alignwide">
-	<!-- wp:columns {"align":"wide","style":{"spacing":{"blockGap":{"top":"0"},"margin":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|30"}}}} -->
-	<div class="wp-block-columns alignwide" style="margin-top:var(--wp--preset--spacing--50);margin-bottom:var(--wp--preset--spacing--30)">
-		<!-- wp:column -->
-		<div class="wp-block-column">
-			<!-- wp:heading -->
-			<h2 class="wp-block-heading"><?php esc_html_e( 'This Section', 'goodbids' ); ?></h2>
-			<!-- /wp:heading -->
-		</div>
-		<!-- /wp:column -->
-
-		<!-- wp:column -->
-		<div class="wp-block-column">
-			<!-- wp:heading {"level":3} -->
-			<h3 class="wp-block-heading"><?php esc_html_e( 'This Chapter', 'goodbids' ); ?></h3>
-			<!-- /wp:heading -->
-
-			<!-- wp:paragraph -->
-			<p><?php esc_html_e( 'We’re turning charity auctions and fundraising upside down and inside out.', 'goodbids' ); ?></p>
-			<!-- /wp:paragraph -->
-
-			<!-- wp:paragraph -->
-			<p><?php esc_html_e( 'A GOODBIDS positive auction has a great prize, and you can submit bids, but the big difference is that every bid is a non-refundable donation to a charity you care about.', 'goodbids' ); ?></p>
-			<!-- /wp:paragraph -->
-
-			<!-- wp:paragraph -->
-			<p><?php esc_html_e( 'That means that great prizes end up going for really low bids. And charities end up raising more money at the same time.', 'goodbids' ); ?></p>
-			<!-- /wp:paragraph -->
-
-			<!-- wp:heading {"level":3} -->
-			<h3 class="wp-block-heading"><?php esc_html_e( 'This Chapter', 'goodbids' ); ?></h3>
-			<!-- /wp:heading -->
-
-			<!-- wp:paragraph -->
-			<p><?php esc_html_e( 'All you need to do is find an auction you like and place a bid. The money goes directly to the charity and you’ll get a receipt for your tax deductible donation.', 'goodbids' ); ?></p>
-			<!-- /wp:paragraph -->
-		</div>
-		<!-- /wp:column -->
-	</div>
-	<!-- /wp:columns -->
-</div>
-<!-- /wp:group -->
-
-<!-- wp:group {"align":"wide","layout":{"type":"constrained"}} -->
-<div class="wp-block-group alignwide">
-	<!-- wp:columns {"align":"wide","style":{"spacing":{"blockGap":{"top":"0"},"margin":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|30"}}}} -->
-	<div class="wp-block-columns alignwide" style="margin-top:var(--wp--preset--spacing--50);margin-bottom:var(--wp--preset--spacing--30)">
-		<!-- wp:column -->
-		<div class="wp-block-column">
-			<!-- wp:heading -->
-			<h2 class="wp-block-heading"><?php esc_html_e( 'This Section', 'goodbids' ); ?></h2>
+			<!-- wp:heading {"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|50"}}}} -->
+			<h2 class="wp-block-heading" style="margin-bottom:var(--wp--preset--spacing--50)"><?php esc_html_e( 'This Section', 'goodbids' ); ?></h2>
 			<!-- /wp:heading -->
 		</div>
 		<!-- /wp:column -->

--- a/client-mu-plugins/goodbids/views/patterns/template-terms-conditions.php
+++ b/client-mu-plugins/goodbids/views/patterns/template-terms-conditions.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Pattern: Terms and Conditions Template
+ *
+ * @since 1.0.0
+ * @package GoodBids
+ */
+
+?>
+
+<!-- wp:group {"align":"wide","layout":{"type":"constrained","justifyContent":"left"}} -->
+<div class="wp-block-group alignwide">
+	<!-- wp:post-title {"level":1,"align":"wide"} /-->
+</div>
+<!-- /wp:group -->
+
+<?php foreach ( range( 0, 2 ) as $i ) : ?>
+	<!-- wp:pattern {"slug":"goodbids/section-sidebar-chapters"} /-->
+<?php endforeach; ?>


### PR DESCRIPTION
# Summary
Fixes a few things from QA:
- Changes the `section-sidebar-chapters` pattern to just be one Section + Chapter. 
- Creates a new pattern called Terms and Conditions template which has the title and pulls in three of the `section-sidebar-chapters` patterns.
- Adds bottom margin to the `This Section` title which shows up on mobile when the items stack. 


## Issues

* List any related issues.

## Testing Instructions

1. Go to any page and add a new pattern. 
2. Select the `Terms and Conditions` pattern. 
3. Select the `Section with Sidebar and Chapters` pattern.

## Screenshots

| Section with Sidebar and Chapters | Terms and Conditions |
|--------|--------|
| <img width="649" alt="Screenshot 2024-01-16 at 7 46 17 PM" src="https://github.com/Good-Bids/goodbids/assets/91974372/2994751e-96be-4743-a47f-d7765c6f2cc4"> | <img width="652" alt="Screenshot 2024-01-16 at 7 46 25 PM" src="https://github.com/Good-Bids/goodbids/assets/91974372/c182fffd-175d-43ce-b716-7c8d5e38ca94">| 


### Mobile View
<img width="352" alt="Screenshot 2024-01-16 at 7 46 43 PM" src="https://github.com/Good-Bids/goodbids/assets/91974372/8fd048d5-95b3-4cb9-920c-6119ba46dbf0">
