### PR TITLE
[#178] Lock bidding block on auction

### DIFF
--- a/client-mu-plugins/goodbids/views/patterns/template-auction.php
+++ b/client-mu-plugins/goodbids/views/patterns/template-auction.php
@@ -30,7 +30,7 @@
 
 			<!-- wp:acf/bid-now {"name":"acf/bid-now","mode":"preview"} /-->
 
-			<!-- wp:goodbids/bidding {"auctionId":0} -->
+			<!-- wp:goodbids/bidding {"auctionId":0,"lock":{"move":false,"remove":true}} -->
 				<div id="goodbids-bidding" data-auction-id="0" class="wp-block-goodbids-bidding"></div>
 			<!-- /wp:goodbids/bidding -->
 


### PR DESCRIPTION
# Summary

This locks the bidding block from being removed. It can still be moved around the page, but can not be removed. 

## Issues

* #178

## Testing Instructions

1. Create a new auction and make sure the bidding block can not be removed. (if you are viewing as a super admin you will still be able to remove it)

## Screenshots

NA
