### PR TITLE
[n/a] removing @import global-woocommerce

### DIFF
--- a/client-mu-plugins/goodbids/src/assets/css/main.css
+++ b/client-mu-plugins/goodbids/src/assets/css/main.css
@@ -9,7 +9,6 @@
 
 /* WooCommerce overrides */
 @import 'woocommerce/checkout.css';
-@import 'woocommerce/global-woocommerce.css';
 @import 'woocommerce/my-account.css';
 
 @tailwind base;


### PR DESCRIPTION
# Summary

Removes `@import 'woocommerce/global-woocommerce.css';` as the file name change to `global-forms`

## Issues

* NA

## Testing Instructions

1. Make sure you can run `npm run build`

## Screenshots

NA