### PR TITLE
[n/a] Fixing the PHP memory error

### DIFF
--- a/client-mu-plugins/goodbids/src/classes/Network/Sites.php
+++ b/client-mu-plugins/goodbids/src/classes/Network/Sites.php
@@ -414,7 +414,15 @@ class Sites {
 					return $html;
 				}
 
-				return get_custom_logo( get_main_site_id() );
+				switch_to_blog( get_main_site_id() );
+				$custom_logo_id = get_theme_mod( 'custom_logo' );
+				restore_current_blog();
+
+				if ( $custom_logo_id ) {
+					return get_custom_logo( get_main_site_id() );
+				}
+
+				return '<!-- No Custom Logo -->';
 			}
 		);
 	}


### PR DESCRIPTION
# Summary

This fixes a bug with setting a nonprofit site logo when there is no logo set on the main site. Instead of just getting the main logo image we check if there is an image ID on the main site. 
If the main site _does have_ a logo then we return that HTML. 
But if not, we return a string `<!-- No Custom Logo -->`. 

## Issues

* NA

## Testing Instructions

1. Go to Appearance -> Editor -> Patterns -> Header.
2. Click on the site logo (if you have one set) and click "Replace".
3. Then select "Reset".
4. Save the header and go to a nonprofit site and make sure you can view the site without a logo. 

## Screenshots

NA
