### PR TITLE
[#258] Fixing Deprecated WC email class error

### DIFF
--- a/client-mu-plugins/goodbids/src/classes/Plugins/WooCommerce/Emails/AuctionWatchersLive.php
+++ b/client-mu-plugins/goodbids/src/classes/Plugins/WooCommerce/Emails/AuctionWatchersLive.php
@@ -145,14 +145,6 @@ class AuctionWatchersLive extends WC_Email {
 				'label'   => __( 'Enable this email notification', 'goodbids' ),
 				'default' => 'yes',
 			],
-			'recipient'          => [
-				'title'       => __( 'Recipient(s)', 'goodbids' ),
-				'type'        => 'text',
-				'desc_tip'    => true,
-				'description' => sprintf( 'Enter recipients (comma separated) for this email. Defaults to <code>%s</code>.', esc_attr( $this->get_recipient() ) ),
-				'placeholder' => '',
-				'default'     => '',
-			],
 			'subject'            => [
 				'title'       => __( 'Subject', 'goodbids' ),
 				'type'        => 'text',


### PR DESCRIPTION
# Summary

The email notification was defaulting to `$this->get_recipient()` which is looking for the current user. But if you are not logged in it sends `null` to `get_recipient` which has `explode` and you can no longer pass `null` to `explode` in PHP 8.1. 

I fixed the error so it defaulted to the email in the site admin. But then realized that AuctionWatchersLive recipients should never be overrideable in the admin as the recipients will be dynamic. So I removed the WP field to change/edit the email recipients. 

## Issues

* #258 

## Testing Instructions

1. Go to an auction page (logged out) and make sure there are no errors in the VIP tool bar.

## Screenshots

<img width="320" alt="Screenshot 2024-01-23 at 3 16 34 PM" src="https://github.com/Good-Bids/goodbids/assets/91974372/62b36edb-979e-4b8f-816f-0d1e313f8c31">
