### PR TITLE
[#242, #270] Auction Going Live

### DIFF
--- a/client-mu-plugins/goodbids/src/blocks/bidding/components/fetcher.tsx
+++ b/client-mu-plugins/goodbids/src/blocks/bidding/components/fetcher.tsx
@@ -22,6 +22,7 @@ export function Fetcher({ auctionId, children }: FetcherProps) {
 		error: auctionError,
 		status: auctionStatus,
 	} = useGetAuction(auctionId);
+
 	const {
 		data: userData,
 		error: userError,

--- a/client-mu-plugins/goodbids/src/blocks/bidding/store/store.ts
+++ b/client-mu-plugins/goodbids/src/blocks/bidding/store/store.ts
@@ -1,20 +1,24 @@
 import { mountStoreDevtool } from 'simple-zustand-devtools';
 import { create } from 'zustand';
-import { BiddingState } from './types';
+import { AuctionStatus, BiddingState } from './types';
 import { UserResponse } from '../utils/get-user';
 import {
 	handleSetInitialAuction,
 	handleSetPollingMode,
 	handleSetUser,
 	handleSetSocketAuction,
+	handleSetSocketMode,
+	handleSetAuctionStatus,
 } from './functions';
 import { AuctionResponse } from '../utils/get-auction';
 import { SocketMessage } from '../utils/types';
 
 type BiddingActions = {
+	setAuctionStatus: (status: AuctionStatus) => void;
 	setInitialAuction: (data: AuctionResponse) => void;
 	setPollingMode: () => void;
 	setSocketAuction: (message: SocketMessage) => void;
+	setSocketMode: (override?: boolean) => void;
 	setUser: (data: UserResponse) => void;
 };
 
@@ -23,7 +27,7 @@ export const useBiddingStore = create<BiddingState & BiddingActions>((set) => ({
 	accountUrl: '',
 	bidUrl: '',
 
-	auctionStatus: 'upcoming',
+	auctionStatus: 'initializing',
 	startTime: new Date(),
 	endTime: new Date(),
 
@@ -45,15 +49,26 @@ export const useBiddingStore = create<BiddingState & BiddingActions>((set) => ({
 	fetchMode: 'no-socket',
 	refetchInterval: undefined,
 
+	setAuctionStatus: (status) => {
+		set(handleSetAuctionStatus(status));
+	},
+
 	setInitialAuction: (data) => {
 		set(handleSetInitialAuction(data));
 	},
+
 	setPollingMode: () => {
 		set(handleSetPollingMode());
 	},
+
 	setSocketAuction: (message) => {
 		set(handleSetSocketAuction(message));
 	},
+
+	setSocketMode: (override) => {
+		set((state) => handleSetSocketMode(state.fetchMode, override));
+	},
+
 	setUser: (data) => {
 		set(handleSetUser(data));
 	},

--- a/client-mu-plugins/goodbids/src/blocks/bidding/store/types.ts
+++ b/client-mu-plugins/goodbids/src/blocks/bidding/store/types.ts
@@ -1,3 +1,11 @@
+export type AuctionStatus =
+	| 'initializing'
+	| 'upcoming'
+	| 'starting'
+	| 'live'
+	| 'closing'
+	| 'closed';
+
 export type UrlsType = {
 	socketUrl: string;
 	accountUrl: string;
@@ -5,7 +13,7 @@ export type UrlsType = {
 };
 
 export type TimingType = {
-	auctionStatus: 'upcoming' | 'starting' | 'live' | 'closing' | 'closed';
+	auctionStatus: AuctionStatus;
 	startTime: Date;
 	endTime: Date;
 };


### PR DESCRIPTION
# Summary

- Adjusts countdown timer to handle auction starting
- Adjusts render of countdown timer to fade in instead of pop
- Adds initializing state to auction

## Issues

- #242
- #270

## Testing Instructions

1. Create an auction that starts soon (within the next couple of minutes but not within 1 minute)
2. Visit auction.
3. Open network console
4. 1 minute before the auction starts, see a new request to WP for auction details

If that request did not include a startTime change, wait until countdown timer hits 0
6. See a websocket connection start


If the request _did_ include a startTime change
6. See timer update

