### PR TITLE
[#283] Format Auction

### DIFF
--- a/client-mu-plugins/goodbids/blocks/auction-metrics-general/render.php
+++ b/client-mu-plugins/goodbids/blocks/auction-metrics-general/render.php
@@ -30,7 +30,7 @@ endif;
 			<p class="m-0 font-thin uppercase has-x-small-font-size"><?php esc_html_e( 'Auction Goal', 'goodbids' ); ?></p>
 			<?php
 				printf(
-					'<p class="m-1 font-extrabold">%s</p>',
+					'<p class="m-1 font-extrabold has-large-font-size">%s</p>',
 					wp_kses_post( wc_price( $goal ) )
 				);
 			?>
@@ -45,7 +45,7 @@ endif;
 			<p class="m-0 font-thin uppercase has-x-small-font-size"><?php esc_html_e( 'Est. Value', 'goodbids' ); ?></p>
 			<?php
 				printf(
-					'<p class="m-1 font-extrabold">%s</p>',
+					'<p class="m-1 font-extrabold has-large-font-size">%s</p>',
 					wp_kses_post( wc_price( $estimated_value ) )
 				);
 			?>
@@ -60,7 +60,7 @@ endif;
 			<p class="m-0 font-thin uppercase has-x-small-font-size"><?php esc_html_e( 'High Bid Goal', 'goodbids' ); ?></p>
 			<?php
 				printf(
-					'<p class="m-1 font-extrabold">%s</p>',
+					'<p class="m-1 font-extrabold has-large-font-size">%s</p>',
 					wp_kses_post( wc_price( $expected_high_bid ) )
 				);
 			?>

--- a/client-mu-plugins/goodbids/src/classes/Plugins/WooCommerce.php
+++ b/client-mu-plugins/goodbids/src/classes/Plugins/WooCommerce.php
@@ -105,6 +105,9 @@ class WooCommerce {
 		// Let WooCommerce know about some custom meta keys.
 		$this->register_meta_keys();
 
+		// Trim zeros on the prices
+		$this->price_trim_zeros();
+
 		// New Site Setup.
 		$this->configure_new_site();
 
@@ -193,6 +196,17 @@ class WooCommerce {
 			}
 		);
 	}
+
+	/**
+	 * Trim zeros in price decimals
+	 *
+	 * @since 1.0.0
+	 * @return void
+	 */
+	private function price_trim_zeros(): void {
+		add_filter( 'woocommerce_price_trim_zeros', '__return_true' );
+	}
+
 
 	/**
 	 * Configure WooCommerce settings for new sites.


### PR DESCRIPTION
# Summary

This PR removes `.00` and makes the font large on metrics to match the bidding block. 

## Issues

* #283 

## Testing Instructions

1. Create a new auction and save it. 
2. View the auction and make sure the metrics match the bidding block font size.
3. Make sure there are no `.00` at the end of the metrics


## Screenshots

<img width="676" alt="Screenshot 2024-01-30 at 10 09 24 AM" src="https://github.com/Good-Bids/goodbids/assets/91974372/13becba2-2700-4514-bd5a-d11fcdd2fe2b">

