### PR TITLE
[#306] Free Bids in Auction Details

### DIFF
--- a/client-mu-plugins/goodbids/src/classes/Auctions/API/Details.php
+++ b/client-mu-plugins/goodbids/src/classes/Auctions/API/Details.php
@@ -119,7 +119,7 @@ class Details extends WC_REST_Controller {
 					'currentBid',
 					'lastBid',
 					'freeBidsAvailable',
-					'freeBidsAllowed'
+					'freeBidsAllowed',
 				]
 			);
 		} elseif ( strtolower( Auctions::STATUS_CLOSED ) === $status ) {


### PR DESCRIPTION
# Summary

- Adds freeBidsAvailable and freeBidsAllowed to auction details for live auctions

## Issues

- #306

## Testing Instructions

1. View a live auction
2. See that the response from WP auction details includes free bid info
