### PR TITLE
[n/a] fixing privacy policy link bug

### DIFF
--- a/client-mu-plugins/goodbids/src/classes/Network/Sites.php
+++ b/client-mu-plugins/goodbids/src/classes/Network/Sites.php
@@ -649,7 +649,7 @@ class Sites {
 
 				return $privacy_policy_link;
 			},
-			get_current_blog_id()
+			get_main_site_id()
 		);
 	}
 


### PR DESCRIPTION
# Summary

The privacy policy link was not showing up on nonprofit sites even though it was set. We just needed to pass `get_main_site_id` to the new `swap` `function` 

## Issues

* NA

## Testing Instructions

1. Go to a nonprofit site and make sure the privacy policy link is pulling from the main site.

## Screenshots

NA
