### PR TITLE
[#339] Prelive and Preclosing

### DIFF
--- a/client-mu-plugins/goodbids/src/blocks/bidding/components/bid-button.tsx
+++ b/client-mu-plugins/goodbids/src/blocks/bidding/components/bid-button.tsx
@@ -7,6 +7,7 @@ export function BidButton() {
 
 	const disabled =
 		isLastBidder ||
+		auctionStatus === 'preclosing' ||
 		auctionStatus === 'closed' ||
 		auctionStatus === 'closing';
 
@@ -18,7 +19,11 @@ export function BidButton() {
 
 	const rewardClasses = clsx('btn-fill text-center');
 
-	if (auctionStatus === 'upcoming' || auctionStatus === 'starting') {
+	if (
+		auctionStatus === 'upcoming' ||
+		auctionStatus === 'starting' ||
+		auctionStatus === 'prelive'
+	) {
 		return null;
 	}
 

--- a/client-mu-plugins/goodbids/src/blocks/bidding/components/countdown-timer/index.tsx
+++ b/client-mu-plugins/goodbids/src/blocks/bidding/components/countdown-timer/index.tsx
@@ -2,7 +2,10 @@ import { TimeRemaining } from './time-remaining';
 import { useEffect, useState } from 'react';
 import { useBiddingState } from '../../store';
 import { AuctionStatus } from '../../store/types';
-import { START_TIME_BUFFER } from '../../utils/constants';
+import {
+	LIVE_AND_CLOSING_DELAY,
+	START_TIME_BUFFER,
+} from '../../utils/constants';
 
 type TimeRemainingType = {
 	status: AuctionStatus;
@@ -33,8 +36,16 @@ function getCountdownTime(
 		return { status: 'upcoming', timeRemainingMs: startTime - now };
 	}
 
+	if (now < startTime + LIVE_AND_CLOSING_DELAY) {
+		return { status: 'prelive', timeRemainingMs: 0 };
+	}
+
 	if (now < endTime) {
 		return { status: 'live', timeRemainingMs: endTime - now };
+	}
+
+	if (now < endTime + LIVE_AND_CLOSING_DELAY) {
+		return { status: 'preclosing', timeRemainingMs: 0 };
 	}
 
 	if (auctionStatus === 'closed') {

--- a/client-mu-plugins/goodbids/src/blocks/bidding/components/countdown-timer/time-remaining-message.tsx
+++ b/client-mu-plugins/goodbids/src/blocks/bidding/components/countdown-timer/time-remaining-message.tsx
@@ -24,6 +24,14 @@ export function TimeRemainingMessage({
 		);
 	}
 
+	if (auctionStatus === 'prelive') {
+		return (
+			<span>
+				<b>Auction starting.</b> Please stand by!
+			</span>
+		);
+	}
+
 	if (auctionStatus === 'live') {
 		if (isLastBidder) {
 			return (
@@ -41,7 +49,7 @@ export function TimeRemainingMessage({
 		);
 	}
 
-	if (auctionStatus === 'closing') {
+	if (auctionStatus === 'closing' || auctionStatus === 'preclosing') {
 		return (
 			<span>
 				<b>Auction closing.</b> Please stand by while we check for any

--- a/client-mu-plugins/goodbids/src/blocks/bidding/components/countdown-timer/time-remaining.tsx
+++ b/client-mu-plugins/goodbids/src/blocks/bidding/components/countdown-timer/time-remaining.tsx
@@ -32,7 +32,11 @@ export function TimeRemaining({
 
 	return (
 		<div className="flex items-center gap-3 px-4 h-12">
-			{auctionStatus === 'closing' ? <LoadingIcon spin /> : <ClockIcon />}
+			{auctionStatus === 'closing' || auctionStatus === 'preclosing' ? (
+				<LoadingIcon spin />
+			) : (
+				<ClockIcon />
+			)}
 
 			<div className="relative w-full">
 				<span className={placeholderClasses}>

--- a/client-mu-plugins/goodbids/src/blocks/bidding/components/earn-free-bids.tsx
+++ b/client-mu-plugins/goodbids/src/blocks/bidding/components/earn-free-bids.tsx
@@ -5,7 +5,11 @@ function FreeBidsContent() {
 	const { auctionStatus, currentBid, freeBidsAvailable, isUserLoggedIn } =
 		useBiddingState();
 
-	if (auctionStatus === 'upcoming' || auctionStatus === 'starting') {
+	if (
+		auctionStatus === 'upcoming' ||
+		auctionStatus === 'starting' ||
+		auctionStatus === 'prelive'
+	) {
 		if (isUserLoggedIn) {
 			return (
 				<p className="m-0">

--- a/client-mu-plugins/goodbids/src/blocks/bidding/components/metrics.tsx
+++ b/client-mu-plugins/goodbids/src/blocks/bidding/components/metrics.tsx
@@ -46,6 +46,7 @@ export function Metrics() {
 	if (
 		auctionStatus === 'initializing' ||
 		auctionStatus === 'upcoming' ||
+		auctionStatus === 'prelive' ||
 		auctionStatus === 'starting'
 	) {
 		return null;

--- a/client-mu-plugins/goodbids/src/blocks/bidding/components/participation.tsx
+++ b/client-mu-plugins/goodbids/src/blocks/bidding/components/participation.tsx
@@ -17,7 +17,11 @@ function ParticipationContent() {
 		accountUrl,
 	} = useBiddingState();
 
-	if (auctionStatus === 'upcoming' || auctionStatus === 'starting') {
+	if (
+		auctionStatus === 'upcoming' ||
+		auctionStatus === 'starting' ||
+		auctionStatus === 'prelive'
+	) {
 		if (isUserLoggedIn) {
 			return (
 				<p className="m-0 text-center">
@@ -34,7 +38,11 @@ function ParticipationContent() {
 		);
 	}
 
-	if (auctionStatus === 'closed' || auctionStatus === 'closing') {
+	if (
+		auctionStatus === 'closed' ||
+		auctionStatus === 'closing' ||
+		auctionStatus === 'preclosing'
+	) {
 		if (userTotalBids > 0) {
 			return (
 				<p className="m-0 text-center">

--- a/client-mu-plugins/goodbids/src/blocks/bidding/components/socket.tsx
+++ b/client-mu-plugins/goodbids/src/blocks/bidding/components/socket.tsx
@@ -23,6 +23,7 @@ export function Socket({ auctionId }: SocketProps) {
 			onError: () => {
 				setSocketError();
 			},
+			share: true,
 		},
 	);
 

--- a/client-mu-plugins/goodbids/src/blocks/bidding/store/functions.ts
+++ b/client-mu-plugins/goodbids/src/blocks/bidding/store/functions.ts
@@ -22,26 +22,28 @@ export function handleSetUser(data: UserResponse): UserType {
 export const handleSetAuctionStatus = (
 	newStatus: AuctionStatus,
 	currentStatus: AuctionStatus,
-	fetchMode: FetchingType['fetchMode'],
-) => {
+): Partial<TimingType & FetchingType> => {
 	if (newStatus !== currentStatus) {
+		if (newStatus === 'closing') {
+			client.invalidateQueries({
+				queryKey: ['auction'],
+			});
+
+			client.invalidateQueries({
+				queryKey: ['user'],
+			});
+
+			return {
+				auctionStatus: newStatus,
+				fetchMode: 'polling',
+			};
+		}
+
 		// If the auction is starting, invalidate the auction query
 		// and re-fetch it to ensure startTime hasn't changed
 		if (newStatus === 'starting' || newStatus === 'live') {
 			client.invalidateQueries({
 				queryKey: ['auction'],
-			});
-		}
-
-		if (newStatus === 'closing') {
-			if (fetchMode === 'polling') {
-				client.invalidateQueries({
-					queryKey: ['auction'],
-				});
-			}
-
-			client.invalidateQueries({
-				queryKey: ['user'],
 			});
 		}
 	}

--- a/client-mu-plugins/goodbids/src/blocks/bidding/store/store.ts
+++ b/client-mu-plugins/goodbids/src/blocks/bidding/store/store.ts
@@ -50,13 +50,7 @@ export const useBiddingStore = create<BiddingState & BiddingActions>((set) => ({
 	hasSocketError: false,
 
 	setAuctionStatus: (status) => {
-		set((state) =>
-			handleSetAuctionStatus(
-				status,
-				state.auctionStatus,
-				state.fetchMode,
-			),
-		);
+		set((state) => handleSetAuctionStatus(status, state.auctionStatus));
 	},
 
 	setFetchAuction: (data) => {

--- a/client-mu-plugins/goodbids/src/blocks/bidding/store/types.ts
+++ b/client-mu-plugins/goodbids/src/blocks/bidding/store/types.ts
@@ -2,7 +2,9 @@ export type AuctionStatus =
 	| 'initializing'
 	| 'upcoming'
 	| 'starting'
+	| 'prelive'
 	| 'live'
+	| 'preclosing'
 	| 'closing'
 	| 'closed';
 

--- a/client-mu-plugins/goodbids/src/blocks/bidding/utils/constants.ts
+++ b/client-mu-plugins/goodbids/src/blocks/bidding/utils/constants.ts
@@ -1,2 +1,3 @@
 export const START_TIME_BUFFER = 1000 * 60; // 1 minute
 export const POLLING_INTERVAL = 1000 * 30; // 30 seconds
+export const LIVE_AND_CLOSING_DELAY = 1000; // 1 second


### PR DESCRIPTION
# Summary

When we hit `startTime` or `endTime`, we were requesting auction data from WP, but I _think_ WP was potentially still in the process of updating that information, so Bidding block would get outdated info. This fixes it by adding a 1 second delay between going live and closing.

- Adds a prelive and preclosing step to prevent a race condition

## Issues

- #339

## Testing Instructions

1. Watch an auction go live and close
2. See that we get updated info after each of those steps.

Note that you likely can't meaningfully test this locally since local environment requests take a lot longer than live environment requests.
