### PR TITLE
[#344] Bid Url

### DIFF
--- a/client-mu-plugins/goodbids/src/classes/Auctioneer/Endpoints/Auctions.php
+++ b/client-mu-plugins/goodbids/src/classes/Auctioneer/Endpoints/Auctions.php
@@ -39,6 +39,7 @@ class Auctions {
 		// Set up the payload data with defaults.
 		$payload_data = $this->setup_payload_data(
 			[
+				'bidUrl',
 				'currentBid',
 				'endTime',
 				'freeBidsAllowed',
@@ -106,6 +107,7 @@ class Auctions {
 		// Set up the payload data with defaults.
 		$payload_data = $this->setup_payload_data(
 			[
+				'bidUrl',
 				'currentBid',
 				'endTime',
 				'freeBidsAllowed',


### PR DESCRIPTION
# Summary

The `bidUrl` changes after each bid, but anyone listening on the socket wasn't getting the updated url. This just adds that `bidUrl` to the messages to Auctioneer.

- Adds bid url to body of start and update requests

## Issues

- #344

## Testing Instructions

1. View a live auction with two separate accounts
2. Place a bid with one account
3. See that the bidUrl updates for the second account
