### PR TITLE
[#350] Adding classes for account page

### DIFF
--- a/client-mu-plugins/goodbids/blocks/authentication/render.php
+++ b/client-mu-plugins/goodbids/blocks/authentication/render.php
@@ -16,6 +16,6 @@ if ( is_admin() ) :
 	return;
 endif;
 ?>
-<section <?php block_attr( $block ); ?>>
+<section <?php block_attr( $block, 'woocommerce-account woocommerce-page' ); ?>>
 	<?php echo do_shortcode( '[woocommerce_my_account]' ); ?>
 </section>


### PR DESCRIPTION
# Summary

The custom "authentication" page was not showing the input field correctly or the account info. The fix was to add the WooCommerce parent classes so both of those pages get the default Woo style. 

## Issues

* #350

## Testing Instructions

1. Go to `/my-account/authentication/` and make sure input fields match `/my-account/`
2. Log in and go to `/my-account/authentication/` and make sure the layout match `/my-account/`

## Screenshots

| Before | After |
|--------|--------|
| <img width="1204" alt="Screenshot 2024-02-01 at 10 33 52 AM" src="https://github.com/Good-Bids/goodbids/assets/91974372/519f2849-ae25-4ab2-b42f-a2928d441014"> | <img width="1204" alt="Screenshot 2024-02-01 at 10 34 14 AM" src="https://github.com/Good-Bids/goodbids/assets/91974372/04f7bd7f-7f1d-450d-b69f-f9a62437ce12"> |
| <img width="1222" alt="Screenshot 2024-02-01 at 10 33 59 AM" src="https://github.com/Good-Bids/goodbids/assets/91974372/78362353-6e28-47a2-a193-3e6773002dd5"> | <img width="1197" alt="Screenshot 2024-02-01 at 10 34 09 AM" src="https://github.com/Good-Bids/goodbids/assets/91974372/5757b052-2785-4601-8653-dcb9e034d4dc">  | 
