### PR TITLE
[#356] Implement WP VIP Filter to fix issue w/HyperDB & WooCoupons

### DIFF
--- a/client-mu-plugins/goodbids/src/classes/Plugins/WooCommerce/Coupons.php
+++ b/client-mu-plugins/goodbids/src/classes/Plugins/WooCommerce/Coupons.php
@@ -39,6 +39,9 @@ class Coupons {
 	 * @since 1.0.0
 	 */
 	public function __construct() {
+		// Fixes a known issue with WP VIP and WooCoupons.
+		$this->wp_vip_db_fix();
+
 		// Automatically apply coupons at checkout.
 		$this->apply_cart_coupons();
 	}
@@ -246,6 +249,38 @@ class Coupons {
 			},
 			10,
 			2
+		);
+	}
+
+	/**
+	 * From WP VIP Support:
+	 * This fixes an error that is a known issue of WP VIP (specifically an incompatibility between HyperDB and Woo Coupons).
+	 *
+	 * While we're still waiting on an official fix here, this filter is being used as a workaround where at least two other scenarios the errors have appeared.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return void
+	 */
+	private function wp_vip_db_fix(): void {
+		add_filter(
+			'query',
+			function ( string $query ): string {
+				if ( ! str_contains( $query, 'SELECT' ) || ! str_contains( $query, 'FOR UPDATE' ) ) {
+					return $query;
+				}
+
+				/** @var \hyperdb $wpdb */
+				global $wpdb;
+
+				if ( ! method_exists( $wpdb, 'send_reads_to_master' ) ) {
+					return $query;
+				}
+
+				$wpdb->send_reads_to_master();
+
+				return $query;
+			}
 		);
 	}
 }


### PR DESCRIPTION
# Summary

This PR implements a filter recommended by WP VIP to resolve a database issue where the `--read-only` is set and unable to perform necessary updates made by the WooCoupons functionality.

It was recommended we test this on a non-production environment first, but there's a good probability that this will resolve the errors for now while we wait for a more permanent fix.

## Issues

* #356 

## Testing Instructions

1. I have no idea how to reproduce this other than running another Bidding Games style demo on the Develop or Staging Environment and seeing if it happens again.

## Screenshots
![Screen Shot 2024-02-01 at 10 10 55 AM](https://github.com/Good-Bids/goodbids/assets/122309362/ebd61b47-7073-443f-9fa0-9b30ca00856b)
