### PR TITLE
[#238] Auction Close Email template

### DIFF
--- a/client-mu-plugins/goodbids/src/classes/Plugins/WooCommerce.php
+++ b/client-mu-plugins/goodbids/src/classes/Plugins/WooCommerce.php
@@ -17,6 +17,7 @@ use GoodBids\Plugins\WooCommerce\Checkout;
 use GoodBids\Plugins\WooCommerce\Coupons;
 use GoodBids\Plugins\WooCommerce\Emails\AuctionWatchersLive;
 use GoodBids\Plugins\WooCommerce\Emails\AuctionAdminLive;
+use GoodBids\Plugins\WooCommerce\Emails\AuctionClosed;
 use GoodBids\Plugins\WooCommerce\Orders;
 use WC_Product;
 use WP_Error;
@@ -438,6 +439,7 @@ class WooCommerce {
 				// add the email class to the list of email classes that WooCommerce loads
 				$email_classes['AuctionWatchersLive'] = new AuctionWatchersLive();
 				$email_classes['AuctionAdminLive']    = new AuctionAdminLive();
+				$email_classes['AuctionClosed']       = new AuctionClosed();
 
 				return $email_classes;
 			}

--- a/client-mu-plugins/goodbids/src/classes/Plugins/WooCommerce/Emails/AuctionClosed.php
+++ b/client-mu-plugins/goodbids/src/classes/Plugins/WooCommerce/Emails/AuctionClosed.php
@@ -141,6 +141,7 @@ class AuctionClosed extends WC_Email {
 		return wc_get_template_html(
 			$this->template_html,
 			[
+				'instance'      => $this,
 				'email_heading' => $this->get_default_heading(),
 				'button_text'   => $this->get_default_button_text(),
 			]
@@ -158,6 +159,7 @@ class AuctionClosed extends WC_Email {
 		return wc_get_template_html(
 			$this->template_plain,
 			[
+				'instance'      => $this,
 				'email_heading' => $this->get_default_heading(),
 				'button_text'   => $this->get_default_button_text(),
 			]

--- a/client-mu-plugins/goodbids/views/woocommerce/emails/auction-closed.php
+++ b/client-mu-plugins/goodbids/views/woocommerce/emails/auction-closed.php
@@ -25,88 +25,22 @@ do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
 <p>
 	<?php
 	printf(
-		/* translators: %1$s: Auction title, %2$s: Site title, %3$s: Auction Start Date  */
-		esc_html__( 'Just letting you know that the %1$s auction on the %2$s GOODBIDS site went live on %3$s.', 'goodbids' ),
+		/* translators: %1$s: Auction title, %2$s: Auction total Bids, %3$s: Auction total Raised, %4$s: Site title, %5$s: user Total Bids, %6$s: User Total Donated */
+		esc_html__( 'The %1$s auction has ended with %2$s placed and %3$s raised for %4$s. You supported this auction with %5$s for a total donation of %6$s', 'goodbids' ),
 		'{auction.title}',
+		'{auction.totalBids}',
+		'{auction.totalRaised}',
 		'{site_title}',
-		'{auction.startTime}',
+		'{auction.userTotalBids}',
+		'{auction.userTotalDonated}'
 	);
 	?>
 </p>
-
-
-<div style="margin-bottom: 40px;">
-	<table class="td" cellspacing="0" cellpadding="6" style="width: 100%; font-family: 'Helvetica Neue', Helvetica, Roboto, Arial, sans-serif;" border="1">
-		<thead>
-			<tr>
-				<th class="td" scope="col"><?php esc_html_e( 'Auction Title', 'goodbids' ); ?></th>
-				<th class="td" scope="col"><?php echo '{auction.title}'; ?></th>
-			</tr>
-		</thead>
-		<tbody>
-			<tr>
-				<td class="td"><?php esc_html_e( 'Scheduled Start', 'goodbids' ); ?></td>
-				<td class="td"><?php echo '{auction.startTime}'; ?></td>
-			</tr>
-			<tr>
-				<td class="td"><?php esc_html_e( 'Starting Bid', 'goodbids' ); ?></td>
-				<td class="td"><?php echo '{auction.startingBid}'; ?></td>
-			</tr>
-			<tr>
-				<td class="td"><?php esc_html_e( 'Bid Increment', 'goodbids' ); ?></td>
-				<td class="td"><?php echo '{auction.bidIncrement}'; ?></td>
-			</tr>
-			<?php if ( $auction_goal ) : ?>
-				<tr>
-					<td class="td"><?php esc_html_e( 'Auction Goal', 'goodbids' ); ?></td>
-					<td class="td"><?php echo '{auction.goal}'; ?></td>
-				</tr>
-			<?php endif; ?>
-			<?php if ( $auction_high_bid ) : ?>
-				<tr>
-					<td class="td"><?php esc_html_e( 'Expected High Bid', 'goodbids' ); ?></td>
-					<td class="td"><?php echo '{auction.expectedHighBid}'; ?></td>
-				</tr>
-			<?php endif; ?>
-			<tr>
-				<td class="td"><?php esc_html_e( 'Scheduled End', 'goodbids' ); ?></td>
-				<td class="td"><?php echo '{auction.endTime}'; ?></td>
-			</tr>
-			<tr>
-				<td class="td"><?php esc_html_e( 'Bid Extension', 'goodbids' ); ?></td>
-				<td class="td"><?php echo '{auction.bidExtension}'; ?></td>
-			</tr>
-			<tr>
-				<td class="td"><?php esc_html_e( 'Auction Reward', 'goodbids' ); ?></td>
-				<td class="td"><?php echo '{auction.rewardTitle}'; ?></td>
-			</tr>
-			<tr>
-				<td class="td"><?php esc_html_e( 'Reward Type', 'goodbids' ); ?></td>
-				<td class="td"><?php echo '{auction.rewardType}'; ?></td>
-			</tr>
-			<?php if ( $auction_market_value ) : ?>
-				<tr>
-					<td class="td"><?php esc_html_e( 'Fair Market Value', 'goodbids' ); ?></td>
-					<td class="td"><?php echo '{auction.estimatedValue}'; ?></td>
-				</tr>
-			<?php endif; ?>
-		</tbody>
-	</table>
-</div>
 
 <p>
 	<?php
-	printf(
-		/* translators: %1$s: Auction Start Date/Time, %2$s: Auction Bid Extension */
-		esc_html__( 'The auction will end on %1$s unless a bid is placed within %2$s of the scheduled time. Each subsequent bid will extend the auction length by 15 minutes. We will send you an auction summary when the auction has closed.', 'goodbids' ),
-		'{auction.endTime}',
-		'{auction.bidExtension}',
-	);
+		esc_html_e( 'Check your email or visit the auction page to see if you won!', 'goodbids' );
 	?>
-</p>
-
-<p>
-	<?php echo esc_html__( 'Keep an eye on the auction page for live bidding updates!', 'goodbids' ); ?>
 </p>
 
 <p class="button-wrapper">
@@ -123,13 +57,12 @@ do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
 <p>
 	<?php
 	printf(
-		/* translators: %1$s: Login URL */
-		'<a href="%1$s">Login to your site</a> to view additional auction information.',
-		esc_html( $login_url ),
+		/* translators: %1$s: Main site Auction page url */
+		'Want to support another great GoodBids? <a href="%1$s">View all auctions</a>',
+		'{main.auctionsUrl}'
 	);
 	?>
 </p>
-
 
 <?php
 /** * Show user-defined additional content - this is set in each email's settings. */

--- a/client-mu-plugins/goodbids/views/woocommerce/emails/plain/auction-closed.php
+++ b/client-mu-plugins/goodbids/views/woocommerce/emails/plain/auction-closed.php
@@ -21,102 +21,37 @@ printf(
 echo "\n\n----------------------------------------\n\n";
 
 printf(
-	/* translators: %1$s: Auction title, %2$s: Site title, %3$s: Auction Start Date  */
-	esc_html__( 'Just letting you know that the %1$s auction on the %2$s GOODBIDS site went live on %3$s.', 'goodbids' ),
+	/* translators: %1$s: Auction title, %2$s: Auction total Bids, %3$s: Auction total Raised, %4$s: Site title, %5$s: user Total Bids, %6$s: User Total Donated */
+	esc_html__( 'The %1$s auction has ended with %2$s placed and %3$s raised for %4$s. You supported this auction with %5$s for a total donation of %6$s', 'goodbids' ),
 	'{auction.title}',
+	'{auction.totalBids}',
+	'{auction.totalRaised}',
 	'{site_title}',
-	'{auction.startTime}',
+	'{auction.userTotalBids}',
+	'{auction.userTotalDonated}'
 );
 
 echo "\n\n----------------------------------------\n\n";
 
-esc_html_e( 'Auction Title:', 'goodbids' );
-echo '{auction.title}';
+esc_html_e( 'Check your email or visit the auction page to see if you won!', 'goodbids' );
 
-echo "\n\n----------------------------------------\n\n";
-
-esc_html_e( 'Scheduled Start:', 'goodbids' );
-echo '{auction.startTime}';
-
-echo "\n\n----------------------------------------\n\n";
-
-esc_html_e( 'Starting Bid:', 'goodbids' );
-echo '{auction.startingBid}';
-
-echo "\n\n----------------------------------------\n\n";
-
-esc_html_e( 'Bid Increment:', 'goodbids' );
-echo '{auction.bidIncrement}';
-
-echo "\n\n----------------------------------------\n\n";
-
-if ( $auction_goal ) :
-	esc_html_e( 'Auction Goal:', 'goodbids' );
-	echo '{auction.goal}';
-endif;
-
-echo "\n\n----------------------------------------\n\n";
-
-if ( $auction_high_bid ) :
-	esc_html_e( 'Expected High Bid:', 'goodbids' );
-	echo '{auction.expectedHighBid}';
-endif;
-
-echo "\n\n----------------------------------------\n\n";
-
-esc_html_e( 'Scheduled End:', 'goodbids' );
-echo '{auction.endTime}';
-
-echo "\n\n----------------------------------------\n\n";
-
-esc_html_e( 'Bid Extension:', 'goodbids' );
-echo '{auction.bidExtension}';
-
-echo "\n\n----------------------------------------\n\n";
-
-esc_html_e( 'Auction Reward:', 'goodbids' );
-echo '{auction.rewardTitle}';
-
-echo "\n\n----------------------------------------\n\n";
-
-esc_html_e( 'Reward Type:', 'goodbids' );
-echo '{auction.rewardType}';
-
-echo "\n\n----------------------------------------\n\n";
-
-if ( $auction_market_value ) :
-	esc_html_e( 'Fair Market Value:', 'goodbids' );
-	echo '{auction.estimatedValue}';
-endif;
 
 echo "\n\n----------------------------------------\n\n";
 
 printf(
-	/* translators: %1$s: Auction Start Date/Time, %2$s: Auction Bid Extension */
-	esc_html__( 'The auction will end on %1$s unless a bid is placed within %2$s of the scheduled time. Each subsequent bid will extend the auction length by 15 minutes. We will send you an auction summary when the auction has closed.', 'goodbids' ),
-	'{auction.endTime}',
-	'{auction.bidExtension}',
-);
-
-echo "\n\n----------------------------------------\n\n";
-
-esc_html_e( 'Keep an eye on the auction page for live bidding updates!', 'goodbids' );
-
-echo "\n\n----------------------------------------\n\n";
-
-printf(
-	/* translators: %1$s: Bid Now, %2$s: Auction page url */
-	'%1$s at %2$s',
-	esc_html( $button_text ),
-	'{auction.url}'
+	/* translators: %1$s: Auction page url, %2$s: Bid Now */
+	'<a class="button" href="%1$s">%2$s</a>',
+	'{auction.url}',
+	esc_html( $button_text )
 );
 
 echo "\n\n----------------------------------------\n\n";
 
 printf(
-	/* translators: %1$s: Login URL */
-	'Login to your site to view additional auction information: %1$s',
-	esc_html( $login_url ),
+	/* translators: %1$s: Main site All Auctions page url */
+	'Want to support another great GoodBids? <a class="button" href="%1$s">View all auctions</a>',
+	'{auction.url}',
+	'{main.allAuctionsUrl}'
 );
 
 /**


### PR DESCRIPTION
# Summary

Sets up the Auction close email files. Does not trigger any emails. This also refactors all the current email templates over to tokens. 

## Issues

* #238

## Testing Instructions

1. Go to the WooCommerce settings -> Emails
2. Make sure you see the notification Auction Close.
3. Send a test email by adding a trigger like add_action( 'woocommerce_reset_password_notification', array( $this, 'trigger' ), 10, 2 );
4. Make sure there are no PHP errors and the email looks the screenshot.

## Screenshots
<img width="669" alt="Screenshot 2024-02-06 at 11 08 25 AM" src="https://github.com/Good-Bids/goodbids/assets/91974372/ebc9f03c-fdde-44e3-9410-371a22f0c5a4">


