### PR TITLE
[#239] Auction Winner Confirmation 

### DIFF
--- a/client-mu-plugins/goodbids/src/classes/Plugins/WooCommerce.php
+++ b/client-mu-plugins/goodbids/src/classes/Plugins/WooCommerce.php
@@ -20,6 +20,7 @@ use GoodBids\Plugins\WooCommerce\Emails\AuctionClosed;
 use GoodBids\Plugins\WooCommerce\Emails\AuctionOutbid;
 use GoodBids\Plugins\WooCommerce\Emails\AuctionWatchersLive;
 use GoodBids\Plugins\WooCommerce\Emails\AuctionAdminSummary;
+use GoodBids\Plugins\WooCommerce\Emails\AuctionWinnerConfirmation;
 use GoodBids\Plugins\WooCommerce\Orders;
 use WC_Product;
 use WP_Error;
@@ -439,12 +440,12 @@ class WooCommerce {
 			function ( $email_classes ): array {
 
 				// add the email class to the list of email classes that WooCommerce loads
-				$email_classes['AuctionAdminLive']    = new AuctionAdminLive();
-				$email_classes['AuctionClosed']       = new AuctionClosed();
-				$email_classes['AuctionOutbid']       = new AuctionOutbid();
-				$email_classes['AuctionWatchersLive'] = new AuctionWatchersLive();
-				$email_classes['AuctionAdminSummary'] = new AuctionAdminSummary();
-
+				$email_classes['AuctionAdminLive']          = new AuctionAdminLive();
+				$email_classes['AuctionAdminSummary']       = new AuctionAdminSummary();
+				$email_classes['AuctionClosed']             = new AuctionClosed();
+				$email_classes['AuctionOutbid']             = new AuctionOutbid();
+				$email_classes['AuctionWatchersLive']       = new AuctionWatchersLive();
+				$email_classes['AuctionWinnerConfirmation'] = new AuctionWinnerConfirmation();
 
 				return $email_classes;
 			}

--- a/client-mu-plugins/goodbids/src/classes/Plugins/WooCommerce/Emails/AuctionWinnerConfirmation.php
+++ b/client-mu-plugins/goodbids/src/classes/Plugins/WooCommerce/Emails/AuctionWinnerConfirmation.php
@@ -1,0 +1,231 @@
+<?php
+/**
+ * Auction Winner Confirmation: Send an email to the user that won an auction.
+ *
+ * @since 1.0.0
+ * @package GoodBids
+ */
+
+namespace GoodBids\Plugins\WooCommerce\Emails;
+
+defined( 'ABSPATH' ) || exit;
+
+use WC_Email;
+use WP_User;
+
+/**
+ * Auction Watchers Live extend the custom WooCommerce email class
+ *
+ * @since 1.0.0
+ * @extends WC_Email
+ */
+class AuctionWinnerConfirmation extends WC_Email {
+
+	/**
+	 * User ID.
+	 *
+	 * @var integer
+	 */
+	public $user_id;
+
+	/**
+	 * Set email defaults
+	 *
+	 * @since 1.0.0
+	 */
+	public function __construct() {
+		$this->id             = 'goodbids_auction_winner_confirmation';
+		$this->title          = __( 'Auction Winner Confirmation', 'goodbids' );
+		$this->description    = __( 'Notification email is sent when a user has won an auction.', 'goodbids' );
+		$this->template_html  = 'emails/auction-winner-confirmation.php';
+		$this->template_plain = 'emails/plain/auction-winner-confirmation.php';
+
+		// TODO: Trigger this email.
+
+		// Call parent constructor to load any other defaults not explicitly defined here
+		parent::__construct();
+	}
+
+	/**
+	 * Get email subject.
+	 *
+	 * @since  1.0.0
+	 * @return string
+	 */
+	public function get_default_subject() {
+		return sprintf(
+			__( '[%s] Congratulations, you won!', 'goodbids' ),
+			'{site_title}',
+		);
+	}
+
+	/**
+	 * Get email heading.
+	 *
+	 * @since   1.0.0
+	 * @return string
+	 */
+	public function get_default_heading() {
+		return sprintf(
+			__( 'You generosity earned a %s !', 'goodbids' ),
+			'{auction.rewardTitle}'
+		);
+	}
+
+	/**
+	 * Get button text
+	 *
+	 * @since   1.0.0
+	 * @return string
+	 */
+	public function get_default_button_text() {
+		return __( 'Claim Your Reward', 'goodbids' );
+	}
+
+	/**
+	 * Get Reward checkout flow url
+	 *
+	 * @since   1.0.0
+	 * @return string
+	 */
+	public function get_reward_checkout_url() {
+		// TODO set this up to pull the reward checkout url
+		return '#';
+	}
+
+	/**
+	 * Get the email recipients
+	 *
+	 * @return string
+	 */
+	public function get_recipient(): string {
+		$recipient = parent::get_recipient();
+
+		if ( ! $recipient ) {
+			// this sets the recipient to the settings defined below in init_form_fields()
+			$recipient = $this->get_option( 'recipient' );
+		}
+
+		// if none was entered, just use the WP admin email as a fallback
+		if ( ! $recipient ) {
+			$recipient = get_option( 'admin_email' );
+		}
+
+		return $recipient;
+	}
+
+	/**
+	 * Determine if the email should actually be sent and setup email merge variables
+	 *
+	 * @since 1.0.0
+	 * @param mixed $user_id
+	 * @return void
+	 */
+	public function trigger( $user_id ): void {
+		$this->setup_locale();
+
+		// TODO set up check before sending email
+		if ( $user_id ) {
+			$this->object  = new WP_User( $user_id );
+			$this->user_id = $this->object->ID;
+		}
+
+		if ( ! $this->is_enabled() || ! $this->get_recipient() ) {
+			return;
+		}
+
+		// woohoo, send the email!
+		$this->send( $this->get_recipient(), $this->get_subject(), $this->get_content(), $this->get_headers(), $this->get_attachments() );
+
+		$this->restore_locale();
+	}
+
+	/**
+	 * get_content_html function.
+	 *
+	 * @since 1.0.0
+	 * @return string
+	 */
+	public function get_content_html(): string {
+		return wc_get_template_html(
+			$this->template_html,
+			[
+				'instance'          => $this,
+				'email_heading'     => $this->get_default_heading(),
+				'button_text'       => $this->get_default_button_text(),
+				'button_reward_url' => $this->get_reward_checkout_url(),
+			]
+		);
+	}
+
+
+	/**
+	 * get_content_plain function.
+	 *
+	 * @since 1.0.0
+	 * @return string
+	 */
+	public function get_content_plain(): string {
+		return wc_get_template_html(
+			$this->template_plain,
+			[
+				'instance'      => $this,
+				'email_heading' => $this->get_default_heading(),
+				'button_text'   => $this->get_default_button_text(),
+				'reward_url'    => $this->get_reward_checkout_url(),
+			]
+		);
+	}
+
+	/**
+	 * Initialize Settings Form Fields
+	 *
+	 * @since 1.0.0
+	 * @return void
+	 */
+	public function init_form_fields(): void {
+
+		$this->form_fields = [
+			'enabled'            => [
+				'title'   => __( 'Enable/Disable', 'goodbids' ),
+				'type'    => 'checkbox',
+				'label'   => __( 'Enable this email notification', 'goodbids' ),
+				'default' => 'yes',
+			],
+			'subject'            => [
+				'title'       => __( 'Subject', 'goodbids' ),
+				'type'        => 'text',
+				'desc_tip'    => true,
+				'description' => sprintf( 'This controls the email subject line. Leave blank to use the default subject: <code>%s</code>.', $this->get_subject() ),
+				'placeholder' => $this->get_default_subject(),
+				'default'     => '',
+			],
+			'heading'            => [
+				'title'       => __( 'Email Heading', 'goodbids' ),
+				'type'        => 'text',
+				'desc_tip'    => true,
+				'description' => sprintf( __( 'This controls the main heading contained within the email notification. Leave blank to use the default heading: <code>%s</code>.' ), $this->get_heading() ),
+				'placeholder' => $this->get_default_heading(),
+				'default'     => '',
+			],
+			'additional_content' => [
+				'title'       => __( 'Additional content', 'goodbids' ),
+				'description' => __( 'Text to appear below the main email content.', 'goodbids' ),
+				'css'         => 'width:400px; height: 75px;',
+				'placeholder' => __( 'N/A', 'goodbids' ),
+				'type'        => 'textarea',
+				'default'     => $this->get_default_additional_content(),
+				'desc_tip'    => true,
+			],
+			'email_type'         => [
+				'title'       => __( 'Email type', 'goodbids' ),
+				'type'        => 'select',
+				'description' => __( 'Choose which format of email to send.', 'goodbids' ),
+				'default'     => 'html',
+				'class'       => 'email_type wc-enhanced-select',
+				'options'     => $this->get_email_type_options(),
+				'desc_tip'    => true,
+			],
+		];
+	}
+}

--- a/client-mu-plugins/goodbids/views/woocommerce/emails/auction-winner-confirmation.php
+++ b/client-mu-plugins/goodbids/views/woocommerce/emails/auction-winner-confirmation.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * Auction Closed email
+ *
+ * @version 1.0.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/*
+ * @hooked WC_Emails::email_header() Output the email header
+ */
+do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
+
+<p>
+	<?php
+	printf(
+		/* translators: %s: Customer username */
+		esc_html__( 'Hi %s,', 'goodbids' ),
+		'{user.firstName}'
+	);
+	?>
+</p>
+
+<p>
+	<?php
+	printf(
+		/* translators: %1$s: User last bid, %2$s: Auction Title, %3$s: Auction reward title, %4$s: Site title */
+		esc_html__( 'Congratulations! Your %1$s bid was the highest GOODBID for the %2$s auction, and you are the winner. Please claim your %3$s with %4$s within 40 days.', 'goodbids' ),
+		'{auction.userLastBid}',
+		'{auction.title}',
+		'{auction.rewardTitle}',
+		'{site_title}',
+	);
+	?>
+</p>
+
+<p>
+	{auction.rewardClaimInstructions}
+</p>
+
+
+<p class="button-wrapper">
+	<?php
+	printf(
+		/* translators: %1$s: reward checkout page url, %2$s: Claim Your Reward */
+		'<a class="button" href="%1$s">%2$s</a>',
+		esc_html( $button_reward_url ),
+		esc_html( $button_text )
+	);
+	?>
+</p>
+
+<?php
+/** * Show user-defined additional content - this is set in each email's settings. */
+if ( $additional_content ) {
+	echo wp_kses_post( wpautop( wptexturize( $additional_content ) ) );
+}
+
+/* * @hooked WC_Emails::email_footer() Output the email footer */
+do_action( 'woocommerce_email_footer', $email );

--- a/client-mu-plugins/goodbids/views/woocommerce/emails/plain/auction-winner-confirmation.php
+++ b/client-mu-plugins/goodbids/views/woocommerce/emails/plain/auction-winner-confirmation.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Auction Closed email (plain text)
+ *
+ * @version 1.0.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+echo "=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n";
+echo esc_html( wp_strip_all_tags( $email_heading ) );
+echo "\n=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n\n";
+
+
+printf(
+	/* translators: %s: Customer username */
+	esc_html__( 'Hi %s,', 'goodbids' ),
+	'{user.firstName}'
+);
+
+echo "\n\n----------------------------------------\n\n";
+
+printf(
+	/* translators: %1$s: User last bid, %2$s: Auction Title, %3$s: Auction reward title, %4$s: Site title */
+	esc_html__( 'Congratulations! Your %1$s bid was the highest GOODBID for the %2$s auction, and you are the winner. Please claim your %3$s with %4$s within 40 days.', 'goodbids' ),
+	'{auction.userLastBid}',
+	'{auction.title}',
+	'{auction.rewardTitle}',
+	'{site_title}',
+);
+
+echo "\n\n----------------------------------------\n\n";
+
+echo '{auction.rewardClaimInstructions}';
+
+echo "\n\n----------------------------------------\n\n";
+
+printf(
+	/* translators: %1$s: reward checkout page url, %2$s: Claim Your Reward */
+	'<a class="button" href="%1$s">%2$s</a>',
+	esc_html( $button_reward_url ),
+	esc_html( $button_text )
+);
+
+/**
+ * Show user-defined additional content - this is set in each email's settings.
+ */
+if ( $additional_content ) {
+	echo esc_html( wp_strip_all_tags( wptexturize( $additional_content ) ) );
+	echo "\n\n----------------------------------------\n\n";
+}
+
+echo wp_kses_post( apply_filters( 'woocommerce_email_footer_text', get_option( 'woocommerce_email_footer_text' ) ) );


### PR DESCRIPTION
# Summary

Adds the Auction Winner Confirmation notification for users.
It does not include a trigger to send the email or pull in all the auction info from that trigger.

## Issues

#239

## Testing Instructions

1. Go to the WooCommerce settings -> Emails
2. Make sure you see the notification Auction Winner Confirmation.
3. Send a test email by adding a trigger like `add_action( 'woocommerce_reset_password_notification', array( $this, 'trigger' ), 10, 2 );`
4. Make sure there are no PHP errors and the email looks the screenshot.

## Screenshots

<img width="623" alt="Screenshot 2024-02-06 at 3 40 51 PM" src="https://github.com/Good-Bids/goodbids/assets/91974372/1d6c33a7-34e6-47b8-a69b-118aa0b8f014">
