### PR TITLE
[#398] Loading up one trust script into footer

### DIFF
--- a/client-mu-plugins/goodbids/src/classes/Core.php
+++ b/client-mu-plugins/goodbids/src/classes/Core.php
@@ -14,6 +14,7 @@ use GoodBids\Auctions\Auctions;
 use GoodBids\Auctions\Watchers;
 use GoodBids\Blocks\Blocks;
 use GoodBids\Frontend\Notices;
+use GoodBids\Frontend\OneTrust;
 use GoodBids\Frontend\Patterns;
 use GoodBids\Frontend\Vite;
 use GoodBids\Network\Dashboard;
@@ -275,6 +276,8 @@ class Core {
 
 		// Init vite.
 		new Vite();
+		// Init OneTrust.
+		new OneTrust();
 	}
 
 	/**

--- a/client-mu-plugins/goodbids/src/classes/Frontend/OneTrust.php
+++ b/client-mu-plugins/goodbids/src/classes/Frontend/OneTrust.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * OneTrust Implementation
+ *
+ * @since 1.0.0
+ * @package GoodBids
+ */
+
+namespace GoodBids\Frontend;
+
+/**
+ * This class handles loading OneTrust assets.
+ */
+class OneTrust {
+
+	/**
+	 * Initialize the class.
+	 *
+	 * @since 1.0.0
+	 */
+	public function __construct() {
+		$this->get_onetrust_script();
+	}
+
+
+	/**
+	 * OneTrust script
+	 *
+	 * @since 1.0.0
+	 * @return void
+	 */
+	private function get_onetrust_script(): void {
+		add_action(
+			'wp_footer',
+			function () {
+				$onetrust_js        = 'https://cookie-cdn.cookiepro.com/scripttemplates/otSDKStub.js';
+				$data_domain_script = '27e668a7-1a27-4468-a980-700744dc0a20-test';
+
+				printf(
+					'<script src="%s" type="text/javascript" charset="UTF-8" data-domain-script="%s"></script><script type="text/javascript">function OptanonWrapper() { }</script>',
+					esc_url( $onetrust_js ),
+					esc_attr( $data_domain_script ),
+				);
+			}
+		);
+	}
+}


### PR DESCRIPTION
# Summary

This loads the script into the footer of the site to test OneTrust 

## Issues

* #398

## Testing Instructions

1. Go to any site page and make sure a pop up loads at the bottom of the page. 

## Screenshots
<img width="1294" alt="Screenshot 2024-02-09 at 3 41 15 PM" src="https://github.com/Good-Bids/goodbids/assets/91974372/64a1a911-ba7a-4500-aa4d-920c19c41034">

