### PR TITLE
[#392] Updating copy for a11y and moving css to TW

### DIFF
--- a/client-mu-plugins/goodbids/src/assets/css/referral-copy-link.css
+++ b/client-mu-plugins/goodbids/src/assets/css/referral-copy-link.css
@@ -1,87 +1,9 @@
-.goodbids-referrals-copy-link {
-	.tooltip {
-		height: 50px;
-
-		.tooltiptext {
-			background-color: #1c1d1e;
-			border-radius: 6px;
-			bottom: 120%;
-			color: #fff;
-			margin-left: -60px;
-			padding: 5px 0;
-			width: 120px;
-
-			&::after {
-				@apply absolute top-full left-1/2;
-				content: '';
-				margin-left: -5px;
-				border-width: 5px;
-				border-style: solid;
-				border-color: #1c1d1e transparent transparent transparent;
+@layer components {
+	.goodbids-referrals-copy-link {
+		.tooltip {
+			.tooltip-visible {
+				@apply visible block opacity-100;
 			}
 		}
-
-		.tooltip-visible {
-			@apply visible block opacity-100;
-		}
-	}
-
-	.btn-copy {
-		background-color: #eee;
-		background-image: linear-gradient(#fcfcfc, #eee);
-		border-radius: 0 3px 3px 0;
-		border: 1px solid #d5d5d5;
-		color: #333;
-		font-size: 1.5em;
-		font-weight: 700;
-		height: 48px;
-		line-height: 20px;
-		padding: 0 1rem;
-		transition: all 300ms;
-
-		&:hover {
-			background-color: rgba(63, 63, 63, 0.61);
-			background-image: linear-gradient(
-				rgba(79, 79, 79, 0.4),
-				rgba(63, 63, 63, 0.5)
-			);
-			color: #fff;
-		}
-
-		svg {
-			fill: currentColor;
-			height: 1.3rem;
-			max-width: max-content;
-			width: 1.3rem;
-		}
-
-		&:hover svg {
-			fill: #fff;
-		}
-	}
-
-	.copy-link-input {
-		background: #fff;
-		border-radius: 3px 0 0 3px;
-		border: 1px solid #d2d2d2;
-		border-right: 0;
-		box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.075);
-		box-sizing: border-box;
-		color: #696969;
-		flex-grow: 1;
-		font-size: 1em;
-		height: 50px;
-		line-height: normal;
-		padding-left: 1.5rem;
-		transition: opacity 0.5s;
-	}
-
-	input {
-		color: inherit;
-		font: inherit;
-	}
-
-	.input-group-button {
-		width: 1%;
 	}
 }

--- a/client-mu-plugins/goodbids/src/assets/js/copy-to-clipboard.js
+++ b/client-mu-plugins/goodbids/src/assets/js/copy-to-clipboard.js
@@ -22,8 +22,10 @@ function copyToClipboard(text, element) {
 
 function maybeShowTooltip() {
 	const tooltipElement = document.querySelector('.tooltiptext');
+	const tooltipSRText = document.querySelector('.tooltip-sr-text');
 
 	if (tooltipElement) {
+		tooltipSRText.innerText = 'Link copied to clipboard!';
 		tooltipElement.classList.add('tooltip-visible');
 	}
 

--- a/client-mu-plugins/goodbids/tailwind.config.js
+++ b/client-mu-plugins/goodbids/tailwind.config.js
@@ -23,6 +23,7 @@ export default {
 			},
 			borderRadius: {
 				DEFAULT: 'var(--wp--preset--spacing--20)',
+				xs: '0.5rem',
 				sm: 'var(--wp--preset--spacing--10)',
 			},
 			borderWidth: {

--- a/client-mu-plugins/goodbids/views/admin/referrals/copy-link-box.php
+++ b/client-mu-plugins/goodbids/views/admin/referrals/copy-link-box.php
@@ -11,25 +11,29 @@ use GoodBids\Users\Referrals\Referrer;
 
 ?>
 <div class="goodbids-referrals-copy-link">
-	<div class="input-group w-full table">
-		<div class="tooltip relative inline-block w-full">
-			<span class="tooltiptext hidden text-center absolute left-1/2 z-10"><?php esc_html_e( 'Copied!', 'goodbids' ); ?></span>
+	<div class="table w-full input-group">
+		<div class="relative inline-block w-full h-12 tooltip">
+			<span class="absolute z-10 hidden text-center tooltiptext left-1/2 py-1 px-0 -ml-[60px] w-32 bottom-[120%] bg-black text-white rounded-xs after:content-[''] after:-ml-1 after:absolute after:top-full after:left-1/2 after:border-8 after:border-solid after:border-t-black after:border-x-transparent after:border-b-transparent">
+				<?php esc_html_e( 'Copied!', 'goodbids' ); ?>
+			</span>
 			<label>
 				<span class="screen-reader-text"><?php esc_html_e( 'Your Custom Share Link', 'goodbids' ); ?></span>
-				<input class="copy-link-input relative text-left outline-none table-cell w-full overflow-scroll m-0 p-0" readonly type="text" value="<?php echo esc_url( $referrer->get_link() ); ?>">
+				<input class="text-inherit relative table-cell w-full p-0 m-0 overflow-scroll text-left outline-none copy-link-input pl-6 h-[48px] bg-white text-[1em] !text-gray-400 transition-opacity duration-100 rounded-l-xs !rounded-r-none border border-gray-600 border-solid !border-r-0" readonly type="text" value="<?php echo esc_url( $referrer->get_link() ); ?>">
 			</label>
 		</div>
 
-		<span class="input-group-button align-middle table-cell">
+		<span class="table-cell w-1/12 align-middle input-group-button">
 			<a
 				href="#"
-				class="btn-copy relative inline-flex justify-center items-center whitespace-nowrap cursor-pointer select-none appearance-none m-0 p-0"
+				class="relative inline-flex items-center justify-center p-0 m-0 appearance-none cursor-pointer select-none btn-copy whitespace-nowrap h-[50px] px-4 bg-gray-800 rounded-r-xs border border-gray-400 text-gray-100 font-bold text-['1.5em'] transition-colors duration-100 hover:bg-gray-200 hover:text-gray-900 focus:bg-gray-200 focus:text-gray-900"
 				data-clipboard="<?php echo esc_url( $referrer->get_link() ); ?>"
 				data-silent="1"
 				title="<?php esc_attr_e( 'Copy to Clipboard', 'goodbids' ); ?>"
 			>
-				<svg fill="currentColor" class="align-middle" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 115.77 122.88" xml:space="preserve"><style type="text/css">.st0{fill-rule:evenodd;clip-rule:evenodd;}</style><g><path class="st0" d="M89.62,13.96v7.73h12.19h0.01v0.02c3.85,0.01,7.34,1.57,9.86,4.1c2.5,2.51,4.06,5.98,4.07,9.82h0.02v0.02 v73.27v0.01h-0.02c-0.01,3.84-1.57,7.33-4.1,9.86c-2.51,2.5-5.98,4.06-9.82,4.07v0.02h-0.02h-61.7H40.1v-0.02 c-3.84-0.01-7.34-1.57-9.86-4.1c-2.5-2.51-4.06-5.98-4.07-9.82h-0.02v-0.02V92.51H13.96h-0.01v-0.02c-3.84-0.01-7.34-1.57-9.86-4.1 c-2.5-2.51-4.06-5.98-4.07-9.82H0v-0.02V13.96v-0.01h0.02c0.01-3.85,1.58-7.34,4.1-9.86c2.51-2.5,5.98-4.06,9.82-4.07V0h0.02h61.7 h0.01v0.02c3.85,0.01,7.34,1.57,9.86,4.1c2.5,2.51,4.06,5.98,4.07,9.82h0.02V13.96L89.62,13.96z M79.04,21.69v-7.73v-0.02h0.02 c0-0.91-0.39-1.75-1.01-2.37c-0.61-0.61-1.46-1-2.37-1v0.02h-0.01h-61.7h-0.02v-0.02c-0.91,0-1.75,0.39-2.37,1.01 c-0.61,0.61-1,1.46-1,2.37h0.02v0.01v64.59v0.02h-0.02c0,0.91,0.39,1.75,1.01,2.37c0.61,0.61,1.46,1,2.37,1v-0.02h0.01h12.19V35.65 v-0.01h0.02c0.01-3.85,1.58-7.34,4.1-9.86c2.51-2.5,5.98-4.06,9.82-4.07v-0.02h0.02H79.04L79.04,21.69z M105.18,108.92V35.65v-0.02 h0.02c0-0.91-0.39-1.75-1.01-2.37c-0.61-0.61-1.46-1-2.37-1v0.02h-0.01h-61.7h-0.02v-0.02c-0.91,0-1.75,0.39-2.37,1.01 c-0.61,0.61-1,1.46-1,2.37h0.02v0.01v73.27v0.02h-0.02c0,0.91,0.39,1.75,1.01,2.37c0.61,0.61,1.46,1,2.37,1v-0.02h0.01h61.7h0.02 v0.02c0.91,0,1.75-0.39,2.37-1.01c0.61-0.61,1-1.46,1-2.37h-0.02V108.92L105.18,108.92z"/></g></svg>
+				<span class="sr-only"><?php esc_attr_e( 'Copy to Clipboard', 'goodbids' ); ?></span>
+				<svg fill="currentColor" class="w-6 h-5 align-middle" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 115.77 122.88" xml:space="preserve"><style type="text/css">.st0{fill-rule:evenodd;clip-rule:evenodd;}</style><g><path class="st0" d="M89.62,13.96v7.73h12.19h0.01v0.02c3.85,0.01,7.34,1.57,9.86,4.1c2.5,2.51,4.06,5.98,4.07,9.82h0.02v0.02 v73.27v0.01h-0.02c-0.01,3.84-1.57,7.33-4.1,9.86c-2.51,2.5-5.98,4.06-9.82,4.07v0.02h-0.02h-61.7H40.1v-0.02 c-3.84-0.01-7.34-1.57-9.86-4.1c-2.5-2.51-4.06-5.98-4.07-9.82h-0.02v-0.02V92.51H13.96h-0.01v-0.02c-3.84-0.01-7.34-1.57-9.86-4.1 c-2.5-2.51-4.06-5.98-4.07-9.82H0v-0.02V13.96v-0.01h0.02c0.01-3.85,1.58-7.34,4.1-9.86c2.51-2.5,5.98-4.06,9.82-4.07V0h0.02h61.7 h0.01v0.02c3.85,0.01,7.34,1.57,9.86,4.1c2.5,2.51,4.06,5.98,4.07,9.82h0.02V13.96L89.62,13.96z M79.04,21.69v-7.73v-0.02h0.02 c0-0.91-0.39-1.75-1.01-2.37c-0.61-0.61-1.46-1-2.37-1v0.02h-0.01h-61.7h-0.02v-0.02c-0.91,0-1.75,0.39-2.37,1.01 c-0.61,0.61-1,1.46-1,2.37h0.02v0.01v64.59v0.02h-0.02c0,0.91,0.39,1.75,1.01,2.37c0.61,0.61,1.46,1,2.37,1v-0.02h0.01h12.19V35.65 v-0.01h0.02c0.01-3.85,1.58-7.34,4.1-9.86c2.51-2.5,5.98-4.06,9.82-4.07v-0.02h0.02H79.04L79.04,21.69z M105.18,108.92V35.65v-0.02 h0.02c0-0.91-0.39-1.75-1.01-2.37c-0.61-0.61-1.46-1-2.37-1v0.02h-0.01h-61.7h-0.02v-0.02c-0.91,0-1.75,0.39-2.37,1.01 c-0.61,0.61-1,1.46-1,2.37h0.02v0.01v73.27v0.02h-0.02c0,0.91,0.39,1.75,1.01,2.37c0.61,0.61,1.46,1,2.37,1v-0.02h0.01h61.7h0.02 v0.02c0.91,0,1.75-0.39,2.37-1.01c0.61-0.61,1-1.46,1-2.37h-0.02V108.92L105.18,108.92z"/></g></svg>
 			</a>
+			<span class="sr-only tooltip-sr-text" role="alert"></span>
 		</span>
 
 	</div>

--- a/client-mu-plugins/goodbids/views/woocommerce/myaccount/my-referrals.php
+++ b/client-mu-plugins/goodbids/views/woocommerce/myaccount/my-referrals.php
@@ -13,7 +13,7 @@ use GoodBids\Users\Referrals\Referral;
 <div class="goodbids-account-referrals">
 	<h1><?php esc_html_e( 'Referrals', 'goodbids' ); ?></h1>
 
-	<div><strong><?php esc_html_e( 'Share with Friends to earn Free Bids!', 'goodbids' ); ?></strong></div>
+	<div><p class="mb-0 font-bold"><?php esc_html_e( 'Share with Friends to earn Free Bids!', 'goodbids' ); ?></p></div>
 	<?php echo do_shortcode( '[goodbids-referral return="copy-link"]' ); ?>
 
 	<?php if ( ! $referrals ) : ?>
@@ -32,7 +32,7 @@ use GoodBids\Users\Referrals\Referral;
 				<?php
 				foreach ( $referrals as $referral_data ) :
 					goodbids()->sites->swap(
-						function() use ( $referral_data ) {
+						function () use ( $referral_data ) {
 							$referral = new Referral( $referral_data['referral_id'] );
 							$display  = $referral->get_user() ? $referral->get_user()->display_name : $referral->get_user_id();
 							$r_status = $referral->is_converted() ? __( 'Placed Bid!', 'goodbids' ) : __( 'Pending', 'goodbids' );


### PR DESCRIPTION
# Summary

Brian asked me to help out by adding the items for a11y and moving the CSS over to TW. This uses the default gray TW colors so that they also work in the WP admin. 

## Issues

* #392

## Testing Instructions

1. Go to My Account -> Referrals. 
2. Go to User -> Referral Link


## Screenshots

<img width="811" alt="Screenshot 2024-02-19 at 1 21 24 PM" src="https://github.com/Good-Bids/goodbids/assets/91974372/ae65f636-b25f-4eef-a355-b144e0b5c0c3">

<img width="1219" alt="Screenshot 2024-02-19 at 1 20 45 PM" src="https://github.com/Good-Bids/goodbids/assets/91974372/bc573736-3587-4b54-9d28-c9aaa508c4ca">
