### PR TITLE
[#429] NP Header logo / WooCommerce header

### DIFF
--- a/client-mu-plugins/goodbids/src/assets/css/patterns/header.css
+++ b/client-mu-plugins/goodbids/src/assets/css/patterns/header.css
@@ -1,10 +1,12 @@
 @layer components {
-	a.custom-logo-link {
-		@apply h-[48px];
-	}
+	.header-nonprofit {
+		a.custom-logo-link {
+			@apply size-[48px] rounded-sm flex;
+		}
 
-	.wp-block-site-logo img.custom-logo {
-		@apply h-full w-[48px] object-contain;
+		.wp-block-site-logo img.custom-logo {
+			@apply object-contain p-1;
+		}
 	}
 
 	.wp-block-woocommerce-customer-account {

--- a/themes/goodbids-main/templates/page-checkout.html
+++ b/themes/goodbids-main/templates/page-checkout.html
@@ -1,0 +1,9 @@
+<!-- wp:template-part {"slug":"header","area":"header","tagName":"header"} /-->
+<!-- wp:woocommerce/page-content-wrapper {"page":"checkout"} -->
+<!-- wp:group {"tagName":"main","layout":{"type":"constrained"}} -->
+<main class="wp-block-group">
+	<!-- wp:post-title {"align":"wide", "level":1} /-->
+	<!-- wp:post-content {"align":"wide"} /-->
+</main>
+<!-- /wp:group -->
+<!-- /wp:woocommerce/page-content-wrapper -->

--- a/themes/goodbids-nonprofit/patterns/header-nonprofit.php
+++ b/themes/goodbids-nonprofit/patterns/header-nonprofit.php
@@ -1,13 +1,13 @@
 <!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"20px","bottom":"20px"}}},"layout":{"type":"constrained"}} -->
-<div class="wp-block-group alignwide has-background" style="padding-top:20px;padding-bottom:20px">
+<div class="wp-block-group alignwide has-background header-nonprofit" style="padding-top:20px;padding-bottom:20px">
 	<!-- wp:group {"align":"wide","layout":{"type":"flex","justifyContent":"space-between","flexWrap":"wrap"}} -->
 	<div class="wp-block-group alignwide">
-		<!-- wp:group {"style":{"spacing":{"blockGap":"0.2rem"},"layout":{"selfStretch":"fit","flexSize":null}},"layout":{"type":"flex"}} -->
-		<div class="wp-block-group">
 
-			<!-- wp:group {"style":{"border":{"radius":"0px"}},"layout":{"type":"constrained"}} -->
-			<div class="overflow-hidden rounded-xs wp-block-group">
-				<!-- wp:site-logo {"width":48,"shouldSyncIcon":false,"className":"is-style-default","style":{"spacing":{"margin":{"top":"0","bottom":"0","left":"0","right":"1rem"}}}} /-->
+		<!-- wp:group {"style":{"spacing":{"blockGap":"1rem"},"layout":{"selfStretch":"fit","flexSize":null}},"layout":{"type":"flex"}} -->
+		<div class="wp-block-group">
+			<!-- wp:group {"style":{"spacing":{"blockGap":"0"}},"className":"overflow-hidden rounded","layout":{"type":"default"}} -->
+			<div class="wp-block-group">
+				<!-- wp:site-logo {"width":48,"shouldSyncIcon":false,"className":"is-style-default","style":{"spacing":{"margin":{"top":"0","bottom":"0","left":"0","right":"0"}}}} /-->
 			</div>
 			<!-- /wp:group -->
 


### PR DESCRIPTION
# Summary

Updates the NP logo to be a 48x48 square with rounded corners. Update the WC checkout header to pull in the default NP header. Any edits to the header will now roll out to the checkout header as well. 

*Note* the WC checkout header will only show up on new sites, has to do with now WooCommerce initiates the templates. 

## Issues

* #429

## Testing Instructions

1. Create a new site. 
2. Add a logo and check to make sure it is square with rounded corners. 
3. Create a product and checkout with that product. 
4. Check that the checkout page has the same header as the rest of the site. 

## Screenshots
| Solid BG | Transparent BG |
|--------|--------|
| <img width="744" alt="Screenshot 2024-02-21 at 2 58 53 PM" src="https://github.com/Good-Bids/goodbids/assets/91974372/81382727-c37f-46b0-ad19-b53ba8523f3e"> | <img width="268" alt="Screenshot 2024-02-21 at 2 59 36 PM" src="https://github.com/Good-Bids/goodbids/assets/91974372/9ed7d49e-308a-40f3-a3be-433985196339">| 

### Checkout WooCommerce header
<img width="1333" alt="Screenshot 2024-02-21 at 2 30 44 PM" src="https://github.com/Good-Bids/goodbids/assets/91974372/71203a8c-0f7b-4392-92ce-a5f206fc9d8d">
