### PR TITLE
[#472] Need full url for staging np sites

### DIFF
--- a/client-mu-plugins/goodbids/blocks/watch-auction/render.php
+++ b/client-mu-plugins/goodbids/blocks/watch-auction/render.php
@@ -20,7 +20,7 @@ $button_text   = $watching ? $unwatch_text : $watch_text;
 $watch_class   = 'btn-fill';
 $unwatch_class = 'btn-fill-secondary';
 $button_class  = $watching ? $watch_class : $unwatch_class;
-$post_url      = str_replace( untrailingslashit( site_url() ), '', admin_url( 'admin-ajax.php' ) );
+$post_url      = admin_url( 'admin-ajax.php' );
 ?>
 <div <?php block_attr( $block ); ?>>
 	<button


### PR DESCRIPTION
# Summary

Watch button Ajax is looking for `/wp-admin/admin-ajax.php` which works great for domains like `nonprofit.goodbids.com`, but does not work for `goodbids.com/nonprofit/` domains.

I tested this out locally with `goodbids.com/nonprofit/` and `nonprofit.goodbids.com` domains

## Issues

* #472

## Testing Instructions

1. Watch/Unwatch an auction and make sure it updates the Watchers number

## Screenshots

N/A
