### PR TITLE
[#419] All Auction page tabs

### DIFF
--- a/client-mu-plugins/goodbids/blocks/all-auctions/block.php
+++ b/client-mu-plugins/goodbids/blocks/all-auctions/block.php
@@ -120,6 +120,15 @@ class AllAuctions extends ACFBlock {
 					'site_id' => get_current_blog_id(),
 				]
 			)
+			->filter(
+				fn ( array $auction_data ) => goodbids()->sites->swap(
+					function () use ( $auction_data ) {
+							$auction = goodbids()->auctions->get( $auction_data['post_id'] );
+							return ! $auction->has_ended();
+						},
+					$auction_data['site_id']
+				)
+			)
 			->sortByDesc(
 				function ( array $auction_data ): array {
 					$auction = goodbids()->auctions->get( $auction_data['post_id'] );
@@ -232,9 +241,6 @@ class AllAuctions extends ACFBlock {
 	 * @return array
 	 */
 	private function sort_auctions_by( string $sort, array $auctions = [] ): array {
-		if ( ! $auctions ) {
-			$auctions = $this->get_all_auctions();
-		}
 
 		$sort_method = match ( $sort ) {
 			'newest'   => 'get_start_date_time',

--- a/client-mu-plugins/goodbids/blocks/all-auctions/render.php
+++ b/client-mu-plugins/goodbids/blocks/all-auctions/render.php
@@ -22,6 +22,8 @@ $auctions = $the_block->apply_sort( $auctions );
 $total_count = count( $auctions );
 $total_pages = ceil( $total_count / $the_block->get_auctions_per_page() );
 $auctions    = $the_block->apply_pagination( $auctions );
+
+$active_class = 'btn-fill-secondary outline-dotted outline-1 outline-offset-2 hover:bg-contrast-3 hover:text-contrast focus:text-contrast focus:bg-contrast-3';
 ?>
 <section <?php block_attr( $block ); ?>>
 	<div class="mb-12 text-center text-contrast">
@@ -35,7 +37,7 @@ $auctions    = $the_block->apply_pagination( $auctions );
 				<li class="me-2">
 					<a
 						href="<?php echo esc_url( $filter_url ); ?>"
-						class="<?php echo esc_attr( $is_current ? 'btn-fill-secondary' : 'btn-fill' ); ?> block my-1"
+						class="<?php echo esc_attr( $is_current ? $active_class : 'btn-fill' ); ?> block my-1"
 					>
 						<?php echo esc_html( $filter['label'] ); ?>
 					</a>

--- a/client-mu-plugins/goodbids/src/classes/Auctions/Auction.php
+++ b/client-mu-plugins/goodbids/src/classes/Auctions/Auction.php
@@ -13,6 +13,7 @@ use DateTimeImmutable;
 use Exception;
 use GoodBids\Nonprofits\Invoices;
 use GoodBids\Utilities\Log;
+use Goodbids\Network\Sites;
 use WC_Order;
 use WP_User;
 
@@ -191,7 +192,7 @@ class Auction {
 	 *
 	 * @return void
 	 */
-	public function set_bid_variation_id(int $bid_variation_id ): void {
+	public function set_bid_variation_id( int $bid_variation_id ): void {
 		update_post_meta( $this->get_id(), Bids::AUCTION_BID_VARIATION_META_KEY, $bid_variation_id );
 	}
 
@@ -780,6 +781,8 @@ class Auction {
 		// Update the Auction meta to indicate it has started.
 		// This is used for the sole purposes of filtering started auctions from get_starting_auctions() method.
 		update_post_meta( $this->get_id(), self::AUCTION_STARTED_META_KEY, 1 );
+		// Reset the Auction transients.
+		delete_transient( Sites::ALL_AUCTIONS_TRANSIENT );
 
 		return true;
 	}
@@ -817,6 +820,8 @@ class Auction {
 		// Update the Auction meta to indicate it has closed.
 		// This is used for the sole purposes of filtering started auctions from get_closing_auctions() method.
 		update_post_meta( $this->get_id(), self::AUCTION_CLOSED_META_KEY, 1 );
+		// Reset the Auction transients.
+		delete_transient( Sites::ALL_AUCTIONS_TRANSIENT );
 
 		return true;
 	}

--- a/client-mu-plugins/goodbids/src/classes/Network/Sites.php
+++ b/client-mu-plugins/goodbids/src/classes/Network/Sites.php
@@ -746,17 +746,26 @@ class Sites {
 						'site_id' => $site_id,
 					]
 				)
+				->filter(
+					fn ( array $auction_data ) => goodbids()->sites->swap(
+						function () use ( $auction_data ) {
+								$auction = goodbids()->auctions->get( $auction_data['post_id'] );
+								return ! $auction->has_ended();
+							},
+						$auction_data['site_id']
+					)
+				)
 				->sortByDesc(
 					fn ( array $auction_data ) => [
 						'bid_count'    => $this->swap(
-							function() use ( $auction_data ) {
+							function () use ( $auction_data ) {
 								$auction = goodbids()->auctions->get( $auction_data['post_id'] );
 								return $auction->get_bid_count();
 							},
 							$auction_data['site_id']
 						),
 						'total_raised' => $this->swap(
-							function() use ( $auction_data ) {
+							function () use ( $auction_data ) {
 								$auction = goodbids()->auctions->get( $auction_data['post_id'] );
 								return $auction->get_total_raised();
 							},
@@ -799,6 +808,7 @@ class Sites {
 	 * @return void
 	 */
 	private function maybe_clear_transients(): void {
+
 		add_action(
 			'transition_post_status',
 			function ( string $new_status, string $old_status, WP_Post $post ): void {
@@ -1008,7 +1018,7 @@ class Sites {
 			->filter(
 				function ( $auction_data ) {
 					return $this->swap(
-						function() use ( $auction_data ) {
+						function () use ( $auction_data ) {
 							$auction = goodbids()->auctions->get( $auction_data['auction_id'] );
 							return $auction->is_current_user_winner();
 						},


### PR DESCRIPTION
# Summary

Figured out that the sort check if the `$auction` is empty and if it is, it pulls in all auctions. Which "works" but when there are no live or upcoming auctions it pulls in all the auctions even the ended ones. So now if the auctions arrays is empty from filtering the sort does not pull in all the auctions.  

I also noticed a bug that the transient does not get cleared when an auction goes from upcoming to live. So the auction would be removed from upcoming but would never show up on live. So I added to the `trigger_start` and `trigger_close` to delete the transient for auctions. 

## Issues

* #419

## Testing Instructions

1. Create an auction that starts in a few min. 
2. Make sure it shows up in the upcoming section. 
3. Wait for it to go live and refresh the page. 
4. It should move over to the live section and upcoming should show "No auctions found."

## Screenshots

Updated the live/upcoming buttons so it is easier to know what is the current filter you are view.

![Feb-22-2024 10-47-00](https://github.com/Good-Bids/goodbids/assets/91974372/7a13e623-552f-4438-b92b-802e8a14dbec)

