### PR TITLE
Bug Fix: Reseting the admin pages inline class to block.

### DIFF
--- a/client-mu-plugins/goodbids/src/assets/css/admin.css
+++ b/client-mu-plugins/goodbids/src/assets/css/admin.css
@@ -28,6 +28,13 @@
 }
 
 /**
+ * Plugins Page
+ */
+.plugins .inline {
+	@apply !block;
+}
+
+/**
  * Network Dashboard Log Files
  */
 .gb-log-files li {


### PR DESCRIPTION
# Summary

WordPress uses the class `.inline` but TW also uses the class `.inline`. This bug was noticed on the plugin page in the admin. 
Other ideas would be to only load TW on the pages we need. But may be more time then it is worth it. 

## Issues

* NA

## Testing Instructions

1. Go to the Main Admin -> Plugins

## Screenshots

### Before
<img width="665" alt="Screenshot 2024-02-28 at 7 31 54 AM" src="https://github.com/Good-Bids/goodbids/assets/91974372/646078ad-9fdf-450a-a592-b2bd653ab5ee">

### After
<img width="659" alt="Screenshot 2024-02-28 at 7 31 13 AM" src="https://github.com/Good-Bids/goodbids/assets/91974372/cb1b66cd-af61-4b40-b7a2-525c2481ac7b">


