### PR TITLE
Bug Fix: Looping through all sites and clearing transient

### DIFF
--- a/client-mu-plugins/goodbids/src/classes/Auctions/Auction.php
+++ b/client-mu-plugins/goodbids/src/classes/Auctions/Auction.php
@@ -13,7 +13,6 @@ use DateTimeImmutable;
 use Exception;
 use GoodBids\Nonprofits\Invoices;
 use GoodBids\Utilities\Log;
-use Goodbids\Network\Sites;
 use WC_Order;
 use WP_User;
 
@@ -796,7 +795,7 @@ class Auction {
 		do_action( 'goodbids_auction_start', $this->get_id() );
 
 		// Reset the Auction transients.
-		delete_transient( Sites::ALL_AUCTIONS_TRANSIENT );
+		goodbids()->sites->clear_all_site_transients();
 	}
 
 	/**
@@ -833,7 +832,7 @@ class Auction {
 		do_action( 'goodbids_auction_end', $this->get_id() );
 
 		// Reset the Auction transients.
-		delete_transient( Sites::ALL_AUCTIONS_TRANSIENT );
+		goodbids()->sites->clear_all_site_transients();
 	}
 
 	/**

--- a/client-mu-plugins/goodbids/src/classes/Network/Sites.php
+++ b/client-mu-plugins/goodbids/src/classes/Network/Sites.php
@@ -93,7 +93,6 @@ class Sites {
 	private function redirect_on_save_new_site(): void {
 		add_action(
 			'wp_initialize_site',
-
 			/**
 			 * @param WP_Site $new_site New site object.
 			 */
@@ -553,7 +552,7 @@ class Sites {
 					return;
 				}
 
-				delete_transient( self::ALL_AUCTIONS_TRANSIENT );
+				$this->clear_all_site_transients();
 			},
 			10,
 			3
@@ -566,8 +565,21 @@ class Sites {
 					return;
 				}
 
-				delete_transient( self::ALL_AUCTIONS_TRANSIENT );
+				$this->clear_all_site_transients();
 			}
+		);
+	}
+
+	/**
+	 * Clear the transients for all sites
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return void
+	 */
+	public function clear_all_site_transients(): void {
+		$this->loop(
+			fn() => delete_transient( self::ALL_AUCTIONS_TRANSIENT ),
 		);
 	}
 


### PR DESCRIPTION
# Summary

Noticed that the auction transient is not being cleared across all sites. This affects the main site and the My account auction grid. The problem was we were clearing the transient from a site, but it was still cached in other sites. 

Now we are clearing the transient for all sites. 

## Issues

* NA

## Testing Instructions

1. Make a new auction that will come soon.
2. Check the current site auction list.
3. Check the Main site auction list.
4. Make sure they have the same auction for live and upcoming. 

## Screenshots

NA
