### PR TITLE
[#540] Set tax status to none when Bid Product is created 

### DIFF
--- a/client-mu-plugins/goodbids/src/classes/Auctions/Bids.php
+++ b/client-mu-plugins/goodbids/src/classes/Auctions/Bids.php
@@ -181,6 +181,7 @@ class Bids {
 		// Stock Management, Somewhat locked down.
 		$bid_product->set_sold_individually( true );
 		$bid_product->set_virtual( true );
+		$bid_product->set_tax_status( 'none' );
 
 		// Instance Attribute.
 		$instance_attr = new WC_Product_Attribute();


### PR DESCRIPTION
Currently, we're not setting a tax status for Bid Products when they get created, so `tax_status` is defaulting to `taxable`. A a result, customers in locations with tax rates imported for a NP site are being charged tax for bid products. 

This PR _attempts_ to set the tax status for Bid Products to `none` when they get created. I'm not at all familiar with PHP, so   I'm only 50% confident that this PR achieves the desired outcome. I also don't have the site running locally, so I can't check to see if it works 😂. 

BUT, I figured this would get us close enough for @bd-viget to see what we're going for and update as needed. 

cc @bd-viget @shascher 