### PR TITLE
[N/A] Quick Auction Edit URL Fix

### DIFF
--- a/client-mu-plugins/goodbids/src/classes/Auctions/Auction.php
+++ b/client-mu-plugins/goodbids/src/classes/Auctions/Auction.php
@@ -137,7 +137,8 @@ class Auction {
 	 * @return string
 	 */
 	public function get_edit_url(): string {
-		return get_edit_post_link( $this->get_id() );
+		$edit_url = get_edit_post_link( $this->get_id() );
+		return $edit_url ?: '#';
 	}
 
 	/**


### PR DESCRIPTION
# Summary

This PR returns '#" if `get_edit_post_link` returns empty.

## Issues

* N/A

## Testing Instructions

1. Go to Network Admin > GoodBids > Auctions
