### PR TITLE
[#559] Filters Featured Auctions

### DIFF
--- a/client-mu-plugins/goodbids/src/classes/Network/Sites.php
+++ b/client-mu-plugins/goodbids/src/classes/Network/Sites.php
@@ -625,7 +625,6 @@ class Sites {
 				]
 			)
 			->all();
-
 	}
 
 	/**
@@ -639,7 +638,7 @@ class Sites {
 	 * @return array
 	 */
 	public function get_featured_auctions( array $query_args = [] ): array {
-		return collect( $this->get_all_auctions( $query_args ) )
+		return collect( $this->get_all_open_auctions( $query_args ) )
 			->slice( 0, 3 )
 			->values()
 			->all();


### PR DESCRIPTION
# Summary

The Featured auctions were showing closed auctions as well as not being sorted/filtered for bid count and total raised. It looks like this got removed in one of our auction refactors or in a merge. 

This PR just updates were we are getting the auctions. Instead of getting all auctions, we get all open auctions which has all the filtering already in place. 

## Issues

* #559

## Testing Instructions

1. Create an auction and make sure it shows up on the Featured block.
2. Once that auction is closed make sure it gets removed from the Featured block. 

## Screenshots

<img width="1348" alt="Screenshot 2024-03-04 at 9 06 19 AM" src="https://github.com/Good-Bids/goodbids/assets/91974372/0d8aa084-184d-4f6b-b88c-9b23e3378f07">

