### PR TITLE
[#469] Default WooCommerce Settings

### DIFF
--- a/client-mu-plugins/goodbids/src/classes/Plugins/WooCommerce.php
+++ b/client-mu-plugins/goodbids/src/classes/Plugins/WooCommerce.php
@@ -764,6 +764,6 @@ class WooCommerce {
 		};
 
 		add_filter( 'woocommerce_admin_experimental_onboarding_tasklists', $hide_setup_steps );
-		add_filter( 'woocommerce_admin__onboarding_tasklists', $hide_setup_steps ); // Just in case.
+		add_filter( 'woocommerce_admin_onboarding_tasklists', $hide_setup_steps ); // Just in case.
 	}
 }


### PR DESCRIPTION
# Summary

This PR makes some initial adjustments to the WooCommerce options when a new site is initialized. See ticket for changes.

## Issues

* #496 

## Testing Instructions

1. Create a New Nonprofit Site
2. Visit Nonprofit WP Admin (As a Super Admin, otherwise you get GoodBids Onboarding)
3. Click WooCommerce > Home
4. You should see the setup wizard.
5. Skip Guided Setup to go to the last step (link in the top right)
6. Select a Region
7. The next screen should no longer show the Setup Tasks List or the Things to Do Next boxes

Visit WooCommerce > Settings and verify all the rest of the settings match what is outlined in the ticket.

## Screenshots

<img width="1121" alt="Screenshot 2024-03-04 at 12 27 12 PM" src="https://github.com/Good-Bids/goodbids/assets/122309362/95481f60-5511-4192-b9d7-e599bf08d34e">

