### PR TITLE
[#451] Free Bids Context

### DIFF
--- a/client-mu-plugins/goodbids/package.json
+++ b/client-mu-plugins/goodbids/package.json
@@ -11,7 +11,7 @@
     "compile": "tsc",
     "check-engines": "wp-scripts check-engines",
     "check-licenses": "wp-scripts check-licenses",
-    "dev": "webpack serve",
+    "dev": "NODE_ENV=develop webpack serve",
     "format": "prettier --check ./src/**/*.{css,ts,tsx,js}",
     "format:fix": "prettier --write ./src/**/*.{css,ts,tsx,js}",
     "lint": "eslint ./src/**/*.{ts,tsx}",

--- a/client-mu-plugins/goodbids/src/blocks/bidding/components/free-bids-promo/free-bids-content.tsx
+++ b/client-mu-plugins/goodbids/src/blocks/bidding/components/free-bids-promo/free-bids-content.tsx
@@ -5,7 +5,8 @@ import { liveStatuses, upcomingStatuses } from '../../utils/statuses';
 import { fadeAnimation } from '../../utils/animations';
 
 export function FreeBidsContent() {
-	const { auctionStatus, userId, freeBidsAvailable } = useBiddingState();
+	const { auctionStatus, userId, freeBidsAvailable, isLastBidder } =
+		useBiddingState();
 
 	return (
 		<div className="relative">
@@ -17,11 +18,12 @@ export function FreeBidsContent() {
 
 				{liveStatuses.includes(auctionStatus) &&
 					userId &&
-					freeBidsAvailable && <LiveAndUserAndFreeBids />}
+					freeBidsAvailable &&
+					!isLastBidder && <LiveAndUserAndFreeBids />}
 
 				{liveStatuses.includes(auctionStatus) &&
 					userId &&
-					!freeBidsAvailable && <LiveAndUser />}
+					(!freeBidsAvailable || isLastBidder) && <LiveAndUser />}
 
 				{auctionStatus !== 'initializing' && !userId && <NoUser />}
 			</AnimatePresence>
@@ -53,6 +55,11 @@ function UpcomingAndUser() {
 	);
 }
 
+// Displayed if:
+// - the auction is live
+// - the user is logged in
+// - the auction has free bids available
+// - the user is not the last bidder
 function LiveAndUserAndFreeBids() {
 	const { currentBid } = useBiddingState();
 
@@ -67,6 +74,13 @@ function LiveAndUserAndFreeBids() {
 	);
 }
 
+// Displayed if:
+// - the auction is live
+// - the user is logged in
+// and if:
+// - the auction has no free bids available
+// or
+// - the user is the last bidder
 function LiveAndUser() {
 	return (
 		<ContentWrapper>


### PR DESCRIPTION
# Summary

- Adjusts free bid context if user was last bidder

Basically:
```
if auction is live
  and user is logged in
  and free bids are available
  and user is not the last bidder
then
  show the "earn free bids by bidding or sharing" content

if auction is live
  and user is logged in
  and either 
    free bids are not available
    or
    user is the last bidder
then
  show just the "share" content
```

## Issues

#451

## Testing Instructions

1. Create an auction
2. Bid on it
3. See only the "share" content
4. Get outbid
5. See both the "bid and share" content
