### PR TITLE
[#530] Show links to T&C and Privacy Policy pages

### DIFF
--- a/client-mu-plugins/goodbids/src/classes/Plugins/WooCommerce.php
+++ b/client-mu-plugins/goodbids/src/classes/Plugins/WooCommerce.php
@@ -639,30 +639,6 @@ class WooCommerce {
 	}
 
 	/**
-	 * Modify register Page
-	 *
-	 * @since 1.0.0
-	 *
-	 * @return void
-	 */
-	private function modify_checkout_page(): void {
-		add_action(
-			'woocommerce_register_form_end',
-			function () {
-				if ( ! is_user_logged_in() ) {
-					printf(
-						'<p>%s %s %s %s.<p>',
-						esc_html__( 'By registering an account, you agree to GOODBIDS\'', 'goodbids' ),
-						wp_kses_post( goodbids()->sites->get_terms_conditions_link() ),
-						esc_html__( 'and', 'goodbids' ),
-						wp_kses_post( goodbids()->sites->get_privacy_policy_link() )
-					);
-				}
-			}
-		);
-	}
-
-	/**
 	 * Limit access from WooCommerce pages for non-Super Admins.
 	 *
 	 * @since 1.0.0

--- a/client-mu-plugins/goodbids/src/classes/Plugins/WooCommerce/Checkout.php
+++ b/client-mu-plugins/goodbids/src/classes/Plugins/WooCommerce/Checkout.php
@@ -38,7 +38,8 @@ class Checkout {
 		// Automatically mark processing orders as Complete.
 		$this->automatically_complete_orders();
 
-		$this->show_terms_conditions();
+		// Add terms & conditions and privacy policy text to checkout
+		$this->show_terms_conditions_privacy_policy();
 	}
 
 	/**
@@ -193,25 +194,30 @@ class Checkout {
 	}
 
 	/**
-	 * Add terms and conditions and privacy policy to checkout
+	 * Add terms & conditions and privacy policy text to checkout
 	 *
 	 * @since 1.0.0
 	 *
 	 * @return void
 	 */
-	private function show_terms_conditions(): void {
-		add_action(
-			'woocommerce_checkout_terms_and_conditions',
-			function () {
-				printf(
-					'<p>%s %s %s %s.<p>',
-					esc_html__( 'By registering an account, you agree to GOODBIDS\'', 'goodbids' ),
+	private function show_terms_conditions_privacy_policy(): void {
+		add_filter(
+			'render_block',
+			function ( string $block_content, array $block ): string {
+				if ( empty( $block['blockName'] ) || 'woocommerce/checkout-terms-block' !== $block['blockName'] ) {
+					return $block_content;
+				}
+
+				return sprintf(
+					'<p class="mt-10 ml-10">%s %s %s %s.<p>',
+					esc_html__( 'By proceeding with your order, you agree to GOODBIDS\'', 'goodbids' ),
 					wp_kses_post( goodbids()->sites->get_terms_conditions_link() ),
 					esc_html__( 'and', 'goodbids' ),
 					wp_kses_post( goodbids()->sites->get_privacy_policy_link() )
 				);
 			},
-			60
+			10,
+			2
 		);
 	}
 }


### PR DESCRIPTION
# Summary

This adds text to three places on the site. 

- Login block
- Register Block
- Checkout Page

## Issues

* #530

## Testing Instructions

1. Go to the login screen and make sure the text is there for both the login and register block.
2. Place a bid on an auction and make sure the text is just before the "Place Order" button.

## Screenshots
### Login block 
No license key for staging for the OAuth plugin
<img width="476" alt="Screenshot 2024-03-05 at 10 47 14 AM" src="https://github.com/Good-Bids/goodbids/assets/91974372/8bf3e4d2-49f2-4e73-b722-79706c5cae3a">

### Register Block
<img width="485" alt="Screenshot 2024-03-05 at 10 44 25 AM" src="https://github.com/Good-Bids/goodbids/assets/91974372/94107f14-85e5-440d-a57e-286a632e314a">

### Checkout Page
<img width="915" alt="Screenshot 2024-03-05 at 10 42 06 AM" src="https://github.com/Good-Bids/goodbids/assets/91974372/abe303ee-0ec1-4ba8-8747-d74f9de2a3c1">

