### PR TITLE
[#578] Time Remaining Bug

### DIFF
--- a/client-mu-plugins/goodbids/views/parts/auction.php
+++ b/client-mu-plugins/goodbids/views/parts/auction.php
@@ -31,15 +31,15 @@ if ( $auction->has_started() ) {
 	$time = __( 'Ending ', 'goodbids' ) . $auction->get_end_date_time( 'M d' );
 
 
-	if ( $remaining_time->d < 1 ) {
+	if ( $remaining_time->d < 1 && $remaining_time->h >= 1 ) {
 		$clock_svg = true;
 		$time      = $remaining_time->format( '%hh %im' );
-	} elseif ( $remaining_time->d < 1 && $remaining_time->h < 1 ) {
+	}
+	if ( $remaining_time->d < 1 && $remaining_time->h < 1 ) {
 		$time_class .= 'text-red-500';
 		$clock_svg   = true;
 		$time        = $remaining_time->format( '%im' );
 	}
-	// $time = $remaining_time->format( '%dd %hh %im' );
 } else {
 	try {
 		$start_date = new DateTime( $auction->get_start_date_time(), $time_zone );
@@ -47,16 +47,18 @@ if ( $auction->has_started() ) {
 		Log::error( $e->getMessage() );
 		$start_date = $auction->get_start_date_time();
 	}
+
 	$remaining_time = $current_date->diff( $start_date );
 
 	$time = __( 'Coming ', 'goodbids' ) . $auction->get_start_date_time( 'M d' );
 
-	if ( $remaining_time->h < 1 ) {
-		$clock_svg = true;
-		$time      = __( 'Coming in ', 'goodbids' ) . $remaining_time->format( '%im' );
-	} elseif ( $remaining_time->d < 1 ) {
+	if ( $remaining_time->d < 1 && $remaining_time->h >= 1 ) {
 		$clock_svg = true;
 		$time      = __( 'Coming in ', 'goodbids' ) . $remaining_time->format( '%hh %im' );
+	}
+	if ( $remaining_time->d < 1 && $remaining_time->h < 1 ) {
+		$clock_svg = true;
+		$time      = __( 'Coming in ', 'goodbids' ) . $remaining_time->format( '%im' );
 	}
 }
 ?>


### PR DESCRIPTION
# Summary

Auction time in the all auctions grid (or any view that used the auction grid) was showing the wrong time/text when it was ending at the same time but a different day. 
In testing, I found some other small bugs and ended up with the logic that I have. It is the cleanest while still showing the right time when more than 24hrs, less than 24hrs and less than 1hr. 

## Issues

* #578 

## Testing Instructions

1. Create four auctions - or make one auction and adjust the time.
2. First one should end more than 24hrs than your current time. 
3. Second one should end just under than 24hrs then your current time. 
4. Third one should end more than 1hrs than your current time. 
5. Four one should end less than 1hrs than your current time. 
6. The time should go from `Ending Mar X` to `00h 00m` to `0m`

## Screenshots

<img width="1379" alt="Screenshot 2024-03-05 at 11 42 03 AM" src="https://github.com/Good-Bids/goodbids/assets/91974372/f3ca6db8-f48b-4b39-88fe-30faa6459708">

