### PR TITLE
[#599] Adds WP Mail Log Plugin (unactivated)

### DIFF
--- a/client-mu-plugins/goodbids/composer.json
+++ b/client-mu-plugins/goodbids/composer.json
@@ -59,6 +59,7 @@
 		"wpackagist-plugin/woocommerce": "^8.6",
 		"wpackagist-plugin/woocommerce-gateway-stripe": "^8.0",
 		"wpackagist-plugin/woocommerce-services": "^2.5",
+		"wpackagist-plugin/wp-mail-log": "^1.1",
 		"wpengine/advanced-custom-fields-pro": "^6.2"
 	},
 	"require-dev": {

--- a/client-mu-plugins/goodbids/composer.lock
+++ b/client-mu-plugins/goodbids/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6180c9fa6bb0c29d255d1abcd7cf9f85",
+    "content-hash": "c159fc9e6784d699c71d08751236ca25",
     "packages": [
         {
             "name": "composer/installers",
@@ -1345,6 +1345,24 @@
             },
             "type": "wordpress-plugin",
             "homepage": "https://wordpress.org/plugins/woocommerce-services/"
+        },
+        {
+            "name": "wpackagist-plugin/wp-mail-log",
+            "version": "1.1.3",
+            "source": {
+                "type": "svn",
+                "url": "https://plugins.svn.wordpress.org/wp-mail-log/",
+                "reference": "tags/1.1.3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://downloads.wordpress.org/plugin/wp-mail-log.1.1.3.zip"
+            },
+            "require": {
+                "composer/installers": "^1.0 || ^2.0"
+            },
+            "type": "wordpress-plugin",
+            "homepage": "https://wordpress.org/plugins/wp-mail-log/"
         },
         {
             "name": "wpengine/advanced-custom-fields-pro",


### PR DESCRIPTION
# Summary

This PR Adds the WP Mail Log plugin, however it's not required, so by default it's unactivated. Activate it by going to WP Admin > Plugins (or Network Admin > Plugins) and clicking the appropriate Activate links.

## Issues

* #599 

## Testing Instructions

1. Activate and Watch the emails get collected (or not collected)

## Screenshots

<img width="865" alt="Screenshot 2024-03-06 at 1 15 40 PM" src="https://github.com/Good-Bids/goodbids/assets/122309362/e38ebf97-b236-45af-b10d-a9af25d0c4ba">
