### PR TITLE
[#] Button Link Focus

### DIFF
--- a/client-mu-plugins/goodbids/src/components/button-link.tsx
+++ b/client-mu-plugins/goodbids/src/components/button-link.tsx
@@ -8,11 +8,11 @@ export function ButtonLink({ variant = 'outline', ...rest }: ButtonProps) {
 	const classes = clsx(
 		'box-border block w-full cursor-pointer rounded-full px-6 py-3 text-center text-gb-md no-underline outline-none transition-all focus:ring-2 focus:ring-offset-2 active:animate-pulse disabled:cursor-not-allowed',
 		{
-			'border-none bg-gb-green-700 text-white hover:bg-gb-green-100 hover:text-gb-green-900 focus:ring-gb-green-700 disabled:text-white':
+			'border-none bg-gb-green-700 text-white hover:bg-gb-green-100 hover:text-gb-green-900 focus:text-white focus:ring-gb-green-700 disabled:text-white':
 				variant === 'solid',
-			'border-2 border-solid border-gb-green-700 bg-transparent text-gb-green-700 hover:bg-gb-green-100 hover:text-gb-green-900 focus:ring-gb-green-700':
+			'border-2 border-solid border-gb-green-700 bg-transparent text-gb-green-700 hover:bg-gb-green-100 hover:text-gb-green-900 focus:text-gb-green-700 focus:ring-gb-green-700':
 				variant === 'outline',
-			'border-none bg-transparent text-gb-green-700 hover:bg-gb-green-100 hover:underline focus:underline focus:ring-gb-green-700':
+			'border-none bg-transparent text-gb-green-700 hover:bg-gb-green-100 hover:underline focus:text-gb-green-700 focus:underline focus:ring-gb-green-700':
 				variant === 'ghost',
 		},
 	);


### PR DESCRIPTION
# Summary

- Fixes text color on focused button links

## Issues
- [Slack](https://viget.slack.com/archives/C066JTYH6LB/p1709840238533149?thread_ts=1709840036.330619&cid=C066JTYH6LB)

## Testing Instructions

1. Focus a button link (for example, in the onboarding app)
2. See that the text is white, not default link blue

## Screenshots
**Old**
![Screenshot 2024-03-07 at 1 27 06 PM](https://github.com/Good-Bids/goodbids/assets/48295174/1feef814-7bd2-463c-9ea0-1caba9dc5101)

**New**
![Screenshot 2024-03-07 at 2 53 15 PM](https://github.com/Good-Bids/goodbids/assets/48295174/f0ad0926-f64d-436b-8e4e-cacd7e179776)