### PR TITLE
[#629] Updating nav links to include main np site

### DIFF
--- a/client-mu-plugins/goodbids/views/parts/nonprofit-navigation.php
+++ b/client-mu-plugins/goodbids/views/parts/nonprofit-navigation.php
@@ -10,6 +10,6 @@
 
 foreach ( $nav_links as $page_id ) :
 	?>
-	<!-- wp:navigation-link {"label":"<?php echo esc_attr( get_the_title( $page_id ) ); ?>","type":"<?php echo esc_attr( get_post_type( $page_id ) ); ?>","id":<?php echo esc_attr( $page_id ); ?>,"url":"/<?php echo esc_attr( get_post_field( 'post_name', $page_id, 'edit' ) ); ?>","kind":"post-type"} /-->
+	<!-- wp:navigation-link {"label":"<?php echo esc_attr( get_the_title( $page_id ) ); ?>","type":"<?php echo esc_attr( get_post_type( $page_id ) ); ?>","id":<?php echo esc_attr( $page_id ); ?>,"url":"<?php echo esc_url( get_permalink( $page_id ) ); ?>","kind":"post-type"} /-->
 	<?php
 endforeach;


### PR DESCRIPTION
# Summary

This updates the nav link use `get_permalink` which gets the NP site in the URL. 

## Issues

* #629

## Testing Instructions

1. Create a new site.
2. Make sure the two nav links have the full NP URL and not just `/about`

## Screenshots

NA
