### PR TITLE
[#623] Adding the report an issue link to footer

### DIFF
--- a/client-mu-plugins/goodbids/blocks/main-footer/render.php
+++ b/client-mu-plugins/goodbids/blocks/main-footer/render.php
@@ -11,6 +11,7 @@
 $main_footer  = new GoodBids\Blocks\MainFooter( $block );
 $terms_link   = goodbids()->sites->get_terms_conditions_link();
 $privacy_link = goodbids()->sites->get_privacy_policy_link();
+$issue_link   = goodbids()->sites->get_report_issue_link()
 ?>
 <section <?php block_attr( $block, 'wp-block-group alignwide has-background has-global-padding is-layout-constrained wp-block-group-is-layout-constrained' ); ?>>
 	<div class="wp-block-group alignwide has-global-padding is-layout-constrained wp-block-group-is-layout-constrained">
@@ -29,6 +30,12 @@ $privacy_link = goodbids()->sites->get_privacy_policy_link();
 				<?php if ( $privacy_link ) : ?>
 					<p>
 						<?php echo wp_kses_post( $privacy_link ); ?>
+					</p>
+				<?php endif; ?>
+
+				<?php if ( $issue_link ) : ?>
+					<p>
+						<?php echo wp_kses_post( $issue_link ); ?>
 					</p>
 				<?php endif; ?>
 			</div>

--- a/client-mu-plugins/goodbids/src/classes/Network/Sites.php
+++ b/client-mu-plugins/goodbids/src/classes/Network/Sites.php
@@ -153,7 +153,7 @@ class Sites {
 					$_POST['blog']['email'] = wp_get_current_user()->user_email;
 
 					if ( class_exists( 'Events_Store' ) ) {
-						remove_action( 'shutdown', [ Events_Store::instance(), 'maybe_install_during_shutdown'] );
+						remove_action( 'shutdown', [ Events_Store::instance(), 'maybe_install_during_shutdown' ] );
 					}
 				}
 			}
@@ -599,6 +599,37 @@ class Sites {
 				}
 
 				return $terms_conditions_link;
+			}
+		);
+	}
+
+	/**
+	 * Get the Report an issue link.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return ?string
+	 */
+	public function get_report_issue_link(): ?string {
+		return $this->main(
+			function (): string {
+				$report_issue_page = get_page_by_path( 'report-an-issue' );
+				$report_issue_id   = '';
+				$report_issue_link = '';
+
+				if ( $report_issue_page ) {
+					$report_issue_id = $report_issue_page->ID;
+				}
+
+				if ( $report_issue_id ) {
+					$report_issue_link = sprintf(
+						'<a href="%s">%s</a>',
+						get_page_link( $report_issue_id ),
+						get_the_title( $report_issue_id ),
+					);
+				}
+
+				return $report_issue_link;
 			}
 		);
 	}


### PR DESCRIPTION
# Summary

This adds a link to the footer to the report an issue page if we find a slug that matches `report-an-issue`. 
The downside to this is if we want to update the page slug it will no longer link. Long term it would be good to get this as a site option. 

## Issues

* #623

## Testing Instructions

1. Go to main site and create the page with the slug `report-an-issue`. 
2. Go to any NP page and make sure the new page link is added. 

## Screenshots

<img width="1393" alt="Screenshot 2024-03-07 at 2 49 48 PM" src="https://github.com/Good-Bids/goodbids/assets/91974372/fbb4bbe6-cf02-4d14-953b-d5f7977294ae">

