### PR TITLE
[#621] Notices Refactor

### DIFF
--- a/client-mu-plugins/goodbids/src/classes/Auctions/Auction.php
+++ b/client-mu-plugins/goodbids/src/classes/Auctions/Auction.php
@@ -945,11 +945,11 @@ class Auction {
 	 *
 	 * @since 1.0.0
 	 *
-	 * @return void
+	 * @return bool
 	 */
-	public function trigger_start(): void {
+	public function trigger_start(): bool {
 		if ( ! $this->has_started() || $this->start_triggered() ) {
-			return;
+			return false;
 		}
 
 		// Update the Auction meta to indicate it has started.
@@ -962,6 +962,8 @@ class Auction {
 
 		// Reset the Auction transients.
 		goodbids()->sites->clear_all_site_transients();
+
+		return true;
 	}
 
 	/**

--- a/client-mu-plugins/goodbids/src/classes/Auctions/Bids.php
+++ b/client-mu-plugins/goodbids/src/classes/Auctions/Bids.php
@@ -563,11 +563,11 @@ class Bids {
 
 					if ( $auction->maybe_award_free_bid( null, $description ) ) {
 						// TODO: Let the user know they earned a free bid.
-						$redirect = add_query_arg( 'gb-notice', Notices::EARNED_FREE_BID, $redirect );
+						goodbids()->notices->add_notice( Notices::EARNED_FREE_BID );
 					}
 				} else { // Reduce the Free Bid Count for the user.
 					if ( goodbids()->users->redeem_free_bid( $auction_id, $order_id ) ) {
-						$redirect = add_query_arg( 'gb-notice', Notices::FREE_BID_REDEEMED, $redirect );
+						goodbids()->notices->add_notice( Notices::FREE_BID_REDEEMED );
 					}
 				}
 

--- a/client-mu-plugins/goodbids/src/classes/Frontend/Notices.php
+++ b/client-mu-plugins/goodbids/src/classes/Frontend/Notices.php
@@ -264,15 +264,28 @@ class Notices {
 					return;
 				}
 
-				$notice = $this->get_notice();
-
-				if ( ! $notice ) {
-					return;
-				}
-
-				wc_add_notice( $notice['message'], $notice['type'] );
+				$this->add_notice( $this->notice_id );
 			}
 		);
+	}
+
+	/**
+	 * Adds a pre-defined WC Notice
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $notice_id
+	 *
+	 * @return void
+	 */
+	public function add_notice( string $notice_id ) : void {
+		$notice = $this->get_notice( $notice_id );
+
+		if ( ! $notice ) {
+			return;
+		}
+
+		wc_add_notice( $notice['message'], $notice['type'] );
 	}
 
 	/**

--- a/client-mu-plugins/goodbids/src/classes/Plugins/WooCommerce/Cart.php
+++ b/client-mu-plugins/goodbids/src/classes/Plugins/WooCommerce/Cart.php
@@ -122,11 +122,8 @@ class Cart {
 					$checkout_url = wc_get_page_permalink( 'checkout' );
 					$redirect_to  = add_query_arg( 'add-to-cart', $product_id, $checkout_url );
 
-					$args     = [
-						'redirect-to' => urlencode( $redirect_to ),
-						'gb-notice'   => Notices::NOT_AUTHENTICATED,
-					];
-					$redirect = add_query_arg( $args, $auth_url );
+					goodbids()->notices->add_notice( Notices::NOT_AUTHENTICATED );
+					$redirect = add_query_arg( 'redirect-to', urlencode( $redirect_to ), $auth_url );
 
 					wp_safe_redirect( $redirect );
 					exit;
@@ -135,8 +132,8 @@ class Cart {
 				$auction_id = goodbids()->products->get_auction_id_from_product( $product_id );
 
 				if ( ! $auction_id ) {
-					$redirect = add_query_arg( 'gb-notice', Notices::AUCTION_NOT_FOUND, $auth_url );
-					wp_safe_redirect( $redirect );
+					goodbids()->notices->add_notice( Notices::AUCTION_NOT_FOUND );
+					wp_safe_redirect( $auth_url );
 					exit;
 				}
 
@@ -146,21 +143,21 @@ class Cart {
 
 				if ( Bids::ITEM_TYPE === goodbids()->products->get_type( $product_id ) ) {
 					if ( ! $auction->has_started() ) {
-						$redirect = add_query_arg( 'gb-notice', Notices::AUCTION_NOT_STARTED, $auction_url );
-						wp_safe_redirect( $redirect );
+						goodbids()->notices->add_notice( Notices::AUCTION_NOT_STARTED );
+						wp_safe_redirect( $auction_url );
 						exit;
 					}
 
 					if ( $auction->has_ended() ) {
-						$redirect = add_query_arg( 'gb-notice', Notices::AUCTION_HAS_ENDED, $auction_url );
-						wp_safe_redirect( $redirect );
+						goodbids()->notices->add_notice( Notices::AUCTION_HAS_ENDED );
+						wp_safe_redirect( $auction_url );
 						exit;
 					}
 
 					// Make sure they aren't the current high bidder.
 					if ( $auction->is_current_user_winning() ) {
-						$redirect = add_query_arg( 'gb-notice', Notices::ALREADY_HIGH_BIDDER, $auction_url );
-						wp_safe_redirect( $redirect );
+						goodbids()->notices->add_notice( Notices::ALREADY_HIGH_BIDDER );
+						wp_safe_redirect( $auction_url );
 						exit;
 					}
 
@@ -172,20 +169,20 @@ class Cart {
 				 * Reward Items
 				 */
 				if ( ! $auction->has_ended() ) {
-					$redirect = add_query_arg( 'gb-notice', Notices::AUCTION_NOT_ENDED, $auction_url );
-					wp_safe_redirect( $redirect );
+					goodbids()->notices->add_notice( Notices::AUCTION_NOT_ENDED );
+					wp_safe_redirect( $auction_url );
 					exit;
 				}
 
 				if ( ! $auction->is_current_user_winner() ) {
-					$redirect = add_query_arg( 'gb-notice', Notices::NOT_AUCTION_WINNER, $auction_url );
-					wp_safe_redirect( $redirect );
+					goodbids()->notices->add_notice( Notices::NOT_AUCTION_WINNER );
+					wp_safe_redirect( $auction_url );
 					exit;
 				}
 
 				if ( goodbids()->rewards->is_redeemed( $auction_id ) ) {
-					$redirect = add_query_arg( 'gb-notice', Notices::REWARD_ALREADY_REDEEMED, $auction_url );
-					wp_safe_redirect( $redirect );
+					goodbids()->notices->add_notice( Notices::REWARD_ALREADY_REDEEMED );
+					wp_safe_redirect( $auction_url );
 					exit;
 				}
 

--- a/client-mu-plugins/goodbids/src/classes/Plugins/WooCommerce/Checkout.php
+++ b/client-mu-plugins/goodbids/src/classes/Plugins/WooCommerce/Checkout.php
@@ -110,15 +110,13 @@ class Checkout {
 
 				// Make sure Auction has started.
 				if ( ! $auction->has_started() ) {
-					$notice = goodbids()->notices->get_notice( Notices::AUCTION_NOT_STARTED );
-					wc_add_notice( $notice['message'], $notice['type'] );
+					goodbids()->notices->add_notice( Notices::AUCTION_NOT_STARTED );
 					return;
 				}
 
 				// Make sure Auction has not ended.
 				if ( $auction->has_ended() ) {
-					$notice = goodbids()->notices->get_notice( Notices::AUCTION_HAS_ENDED );
-					wc_add_notice( $notice['message'], $notice['type'] );
+					goodbids()->notices->add_notice( Notices::AUCTION_HAS_ENDED );
 					return;
 				}
 
@@ -129,15 +127,13 @@ class Checkout {
 
 				// Make sure Free Bids are allowed.
 				if ( ! $auction->are_free_bids_allowed() ) {
-					$notice = goodbids()->notices->get_notice( Notices::FREE_BIDS_NOT_ELIGIBLE );
-					wc_add_notice( $notice['message'], $notice['type'] );
+					goodbids()->notices->add_notice( Notices::FREE_BIDS_NOT_ELIGIBLE );
 					return;
 				}
 
 				// Make sure the current user has available Free Bids.
 				if ( ! goodbids()->users->get_available_free_bid_count() ) {
-					$notice = goodbids()->notices->get_notice( Notices::NO_AVAILABLE_FREE_BIDS );
-					wc_add_notice( $notice['message'], $notice['type'] );
+					goodbids()->notices->add_notice( Notices::NO_AVAILABLE_FREE_BIDS );
 				}
 			},
 			10,

--- a/client-mu-plugins/goodbids/src/classes/Plugins/WooCommerce/Coupons.php
+++ b/client-mu-plugins/goodbids/src/classes/Plugins/WooCommerce/Coupons.php
@@ -207,7 +207,8 @@ class Coupons {
 				$auction_id = goodbids()->products->get_auction_id_from_product( $product->get_id() );
 
 				if ( ! $auction_id ) {
-					return add_query_arg( 'gb-notice', Notices::AUCTION_NOT_FOUND, $url );
+					goodbids()->notices->add_notice( Notices::AUCTION_NOT_FOUND );
+					return $url;
 				}
 
 				$auction = goodbids()->auctions->get( $auction_id );
@@ -218,28 +219,33 @@ class Coupons {
 
 					if ( ! $auction->is_current_user_winner() ) {
 						WC()->cart->empty_cart();
-						return add_query_arg( 'gb-notice', Notices::NOT_AUCTION_WINNER, $url );
+						goodbids()->notices->add_notice( Notices::NOT_AUCTION_WINNER );
+						return $url;
 					}
 
 					$coupon_code = $this->get_reward_coupon_code( $auction_id, $product->get_id() );
 
 					if ( ! $coupon_code ) {
-						return add_query_arg( 'gb-notice', Notices::GET_REWARD_COUPON_ERROR, $redirect_url );
+						goodbids()->notices->add_notice( Notices::GET_REWARD_COUPON_ERROR );
+						return $redirect_url;
 					}
 				} elseif ( Bids::ITEM_TYPE === $product_type ) {
 					if ( ! empty( $_REQUEST['use-free-bid'] ) ) { // phpcs:ignore
 						if ( ! $auction->are_free_bids_allowed() ) {
-							return add_query_arg( 'gb-notice', Notices::FREE_BIDS_NOT_ELIGIBLE, $url );
+							goodbids()->notices->add_notice( Notices::FREE_BIDS_NOT_ELIGIBLE );
+							return $url;
 						}
 
 						if ( ! goodbids()->users->get_available_free_bid_count() ) {
-							return add_query_arg( 'gb-notice', Notices::NO_AVAILABLE_FREE_BIDS, $url );
+							goodbids()->notices->add_notice( Notices::NO_AVAILABLE_FREE_BIDS );
+							return $url;
 						}
 
 						$coupon_code = $this->get_free_bid_coupon_code( $auction_id, $product->get_id() );
 
 						if ( ! $coupon_code ) {
-							return add_query_arg( 'gb-notice', Notices::GET_FREE_BID_COUPON_ERROR, $redirect_url );
+							goodbids()->notices->add_notice( Notices::GET_FREE_BID_COUPON_ERROR );
+							return $redirect_url;
 						}
 					}
 				}
@@ -249,7 +255,8 @@ class Coupons {
 					// Apply the Coupon.
 					if ( ! WC()->cart->add_discount( $coupon_code ) ) {
 						Log::error( 'There was a problem adding the discount coupon', compact( 'coupon_code' ) );
-						return add_query_arg( 'gb-notice', Notices::APPLY_COUPON_ERROR, $redirect_url );
+						goodbids()->notices->add_notice( Notices::APPLY_COUPON_ERROR );
+						return $redirect_url;
 					}
 				}
 


### PR DESCRIPTION
# Summary

This PR refactors the notices across the site. Instead of adding them as a query string, it simply sets the `wc_add_notice`, which should persist for the next page load for that user. Just about every notice has been adjusted, so if you find a notice not working, please let me know!

## Issues

* #621 

## Testing Instructions

1. Test out all the notices!
