### PR TITLE
[#643] Fix Onboarding for Super Admins

### DIFF
--- a/client-mu-plugins/goodbids/src/classes/Network/Nonprofits.php
+++ b/client-mu-plugins/goodbids/src/classes/Network/Nonprofits.php
@@ -26,6 +26,14 @@ class Nonprofits {
 	const PAGE_SLUG = 'gb-nonprofits';
 
 	/**
+	 * Nonprofits Page Slug
+	 *
+	 * @since 1.0.0
+	 * @var string
+	 */
+	const ONBOARDED_OPTION = 'goodbids_onboarded';
+
+	/**
 	 * @since 1.0.0
 	 * @var ?ScreenOptions
 	 */
@@ -164,7 +172,7 @@ class Nonprofits {
 		}
 
 		return goodbids()->sites->swap(
-			fn () => boolval( get_option( 'goodbids_onboarded' ) ),
+			fn () => boolval( get_option( self::ONBOARDED_OPTION ) ),
 			$site_id
 		);
 	}


### PR DESCRIPTION
# Summary

This PR updates some of the logic that was causing Super Admins to completely skip the Onboarding Wizard.

## Issues

* #643 

## Testing Instructions

1. Create a New Site as Super Admin
2. Visit the WP Admin Dashboard
3. You should be able to go to the Onboarding Wizard (top left)
4. Onboarding should complete as normal.
