### PR TITLE
[#652] Adjust Permissions for Invoices Post Type

### DIFF
--- a/client-mu-plugins/goodbids/src/classes/Nonprofits/Invoices.php
+++ b/client-mu-plugins/goodbids/src/classes/Nonprofits/Invoices.php
@@ -78,6 +78,9 @@ class Invoices {
 		// Make Post Title readonly.
 		$this->disable_post_title_input();
 
+		// Disable Bulk Actions.
+		$this->disable_bulk_actions();
+
 		// Add custom Admin Columns for Watchers.
 		$this->add_admin_columns();
 
@@ -384,6 +387,23 @@ class Invoices {
 	}
 
 	/**
+	 * Disable Edit Bulk Action
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return void
+	 */
+	private function disable_bulk_actions(): void {
+		add_filter(
+			'bulk_actions-edit-' . $this->get_post_type(),
+			function ( array $actions ): array {
+				unset( $actions[ 'edit' ] );
+				return $actions;
+			}
+		);
+	}
+
+	/**
 	 * Returns the Invoice post type slug.
 	 *
 	 * @since 1.0.0
@@ -511,6 +531,7 @@ class Invoices {
 			'manage_' . $this->get_post_type() . '_posts_columns',
 			function ( array $columns ): array {
 				$new_columns = [];
+				unset( $columns['cb'] );
 
 				foreach ( $columns as $column => $label ) {
 					$new_columns[ $column ] = $label;


### PR DESCRIPTION
# Summary

This PR adjusts the capabilities for the Invoices post type so Administrators can view Invoices.

## Issues

* #652 

## Testing Instructions

1. Visit a Nonprofit WP Admin Dashboard as an Administrator (not Super Admin)
2. Click on Invoices in the sidebar.