### PR TITLE
[#] Wizard to Auction links

### DIFF
--- a/client-mu-plugins/goodbids/src/views/auction-wizard/create/finish.tsx
+++ b/client-mu-plugins/goodbids/src/views/auction-wizard/create/finish.tsx
@@ -23,7 +23,7 @@ export function FinishStep() {
 
 			<ButtonLink
 				autoFocus
-				href={`${gbAuctionWizard.adminURL}/wp-admin/post.php?post=${auctionId}&action=edit`}
+				href={`${gbAuctionWizard.adminURL}/post.php?post=${auctionId}&action=edit`}
 				variant="solid"
 			>
 				{__('Customize auction page', 'goodbids')}

--- a/client-mu-plugins/goodbids/src/views/auction-wizard/edit/finish.tsx
+++ b/client-mu-plugins/goodbids/src/views/auction-wizard/edit/finish.tsx
@@ -24,7 +24,7 @@ export function FinishStep({ auctionId }: FinishStepProps) {
 
 			<ButtonLink
 				autoFocus
-				href={`${gbAuctionWizard.adminURL}/wp-admin/post.php?post=${auctionId}&action=edit`}
+				href={`${gbAuctionWizard.adminURL}/post.php?post=${auctionId}&action=edit`}
 				variant="solid"
 			>
 				{__('Return to auction page', 'goodbids')}


### PR DESCRIPTION
# Summary

- Fixes links from wizard to auctions

## Issues

- Links from the wizard to auction edit pages were malformed.

## Testing Instructions

1. Create an auction
2. Click the link at the end and see the auction edit page.
