### PR TITLE
[#603] Testing WP Mail SMTP plugin for MailGun

### DIFF
--- a/client-mu-plugins/goodbids/composer.json
+++ b/client-mu-plugins/goodbids/composer.json
@@ -60,6 +60,7 @@
 		"wpackagist-plugin/woocommerce-gateway-stripe": "^8.0",
 		"wpackagist-plugin/woocommerce-services": "^2.5",
 		"wpackagist-plugin/wp-mail-log": "^1.1",
+		"wpackagist-plugin/wp-mail-smtp": "^4.0",
 		"wpackagist-plugin/zapier": "^1.0",
 		"wpengine/advanced-custom-fields-pro": "^6.2"
 	},

--- a/client-mu-plugins/goodbids/composer.lock
+++ b/client-mu-plugins/goodbids/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b239945ee9e91cdba61f311dbf1ad88a",
+    "content-hash": "3b1962695d29e74254d87586f9075e69",
     "packages": [
         {
             "name": "composer/installers",
@@ -1363,6 +1363,24 @@
             },
             "type": "wordpress-plugin",
             "homepage": "https://wordpress.org/plugins/wp-mail-log/"
+        },
+        {
+            "name": "wpackagist-plugin/wp-mail-smtp",
+            "version": "4.0.1",
+            "source": {
+                "type": "svn",
+                "url": "https://plugins.svn.wordpress.org/wp-mail-smtp/",
+                "reference": "tags/4.0.1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://downloads.wordpress.org/plugin/wp-mail-smtp.4.0.1.zip"
+            },
+            "require": {
+                "composer/installers": "^1.0 || ^2.0"
+            },
+            "type": "wordpress-plugin",
+            "homepage": "https://wordpress.org/plugins/wp-mail-smtp/"
         },
         {
             "name": "wpackagist-plugin/zapier",

--- a/client-mu-plugins/goodbids/config.json
+++ b/client-mu-plugins/goodbids/config.json
@@ -10,7 +10,8 @@
     "user-switching",
     "woocommerce",
     "woocommerce-gateway-stripe",
-    "woocommerce-services"
+    "woocommerce-services",
+    "wp-mail-smtp/wp_mail_smtp.php"
   ],
   "post-install-plugins": [
     "accessibility-checker",


### PR DESCRIPTION
# Summary

This adds the plugin WP Mail SMTP so we can send emails through mailgun. 

## Issues

* #603 

## Testing Instructions

1. Can't test right now on local and only allows a few users on dev. But see screenshots of it working.

## Screenshots
Tests with two emails
| Bids | Account |
|--------|--------|
| ![IMG_1230](https://github.com/Good-Bids/goodbids/assets/91974372/36c9eb79-e525-46e8-afcf-0d94873cd241) |![IMG_1229](https://github.com/Good-Bids/goodbids/assets/91974372/c362a05d-f31e-42c9-9152-87ab96e20b17) |



