### PR TITLE
[#513] Capture Site ID when using a Free Bid to Display the Auction Link

### DIFF
--- a/client-mu-plugins/goodbids/src/classes/Auctions/FreeBid.php
+++ b/client-mu-plugins/goodbids/src/classes/Auctions/FreeBid.php
@@ -85,6 +85,14 @@ class FreeBid {
 	public ?string $details = null;
 
 	/**
+	 * ID of the Site Free Bid was Used
+	 *
+	 * @since 1.0.0
+	 * @var ?int
+	 */
+	public ?int $site_id_used = null;
+
+	/**
 	 * ID of the Auction Free Bid was Used
 	 *
 	 * @since 1.0.0
@@ -279,23 +287,27 @@ class FreeBid {
 	 *
 	 * @since 1.0.0
 	 *
-	 * @param ?int    $auction_id
 	 * @param ?string $title
 	 *
 	 * @return void
 	 */
-	public function display_auction_link( ?int $auction_id, ?string $title = '' ): void {
-		if ( ! $auction_id ) {
+	public function display_auction_link( ?string $title = '' ): void {
+		if ( ! $this->auction_id_used || ! $this->site_id_used ) {
 			esc_html_e( 'N/A', 'goodbids' );
 			return;
 		}
 
-		printf(
-			'<a href="%s" title="%s" target="_blank" rel="nofollow noopener">%s (ID: %s)</a>',
-			esc_url( get_permalink( $auction_id ) ),
-			$title ? esc_attr( $title ) : '',
-			esc_html( get_the_title( $auction_id ) ),
-			esc_html( $auction_id )
+		goodbids()->sites->swap(
+			function () use ( $title ) {
+				printf(
+					'<a href="%s" title="%s" target="_blank" rel="nofollow noopener">%s (ID: %s)</a>',
+					esc_url( get_permalink( $this->auction_id_used ) ),
+					$title ? esc_attr( $title ) : '',
+					esc_html( get_the_title( $this->auction_id_used ) ),
+					esc_html( $this->auction_id_used )
+				);
+			},
+			$this->site_id_used
 		);
 	}
 
@@ -324,6 +336,7 @@ class FreeBid {
 		$this->used_date         = current_time( 'Y-m-d H:i:s' );
 		$this->status            = Bids::FREE_BID_STATUS_USED;
 		$this->auction_id_used   = $auction_id;
+		$this->site_id_used      = get_current_blog_id();
 		$this->order_id_redeemed = $order->get_id();
 		$this->bid_value         = $order->get_subtotal();
 

--- a/client-mu-plugins/goodbids/views/woocommerce/myaccount/free-bids.php
+++ b/client-mu-plugins/goodbids/views/woocommerce/myaccount/free-bids.php
@@ -49,7 +49,8 @@ use GoodBids\Auctions\FreeBid;
 							<span><?php $free_bid->display_status(); ?></span>
 						</td>
 						<td class="goodbids-free-bids-table__cell goodbids-free-bids-table__cell-used" data-title="<?php esc_attr_e( 'Used', 'goodbids' ); ?>">
-							<span><?php $free_bid->display_auction_link( $free_bid->auction_id_used ); ?></span>
+							<span><?php $free_bid->display_auction_link(); ?></span>
+
 							<?php if ( $free_bid->used_date ) : ?>
 								<?php esc_html_e( 'on', 'goodbids' ); ?>
 								<span><?php $free_bid->display_used_date(); ?></span>


### PR DESCRIPTION
# Summary

Capture the Site ID when a Free Bid is redeemed so it can be used to display the Auction URL on the My Account > Free Bids table.

## Issues

* #513 

## Testing Instructions

1. Use a free bid
2. Go to My Account > Free Bids
3. It should show the Auction Title/Link instead of N/A

## Screenshots

<img width="764" alt="Screenshot 2024-03-08 at 5 35 13 PM" src="https://github.com/Good-Bids/goodbids/assets/122309362/dd73b1a0-c13b-4c27-b950-89519ebcd504">
