### PR TITLE
[#664] Hiding auction if the site is still pending

### DIFF
--- a/client-mu-plugins/goodbids/src/classes/Network/Sites.php
+++ b/client-mu-plugins/goodbids/src/classes/Network/Sites.php
@@ -655,6 +655,19 @@ class Sites {
 						'site_id' => $site_id,
 					]
 				)
+				->filter(
+					fn () => goodbids()->sites->swap(
+						function () {
+							if ( is_main_site() ) {
+								return true;
+							}
+							// Skip site if status is pending
+							$nonprofit = new Nonprofit( get_current_blog_id() );
+							return Nonprofit::STATUS_PENDING !== $nonprofit->get_status();
+						},
+						$site_id
+					)
+				)
 				->all()
 		);
 


### PR DESCRIPTION
# Summary

This hides the auctions on the main site if the site status is pending. But the auctions still show up when viewing on the pending site. 

## Issues

* #664 

## Testing Instructions

1. Create two auctions one on a site live and one on a pending site.
2. Go to the main site featured list and all auction pages.
3. Make sure the auction on the pending site is not there. 
4. Go to the pending site and view the all auction page and make sure the pending auction is there.  

## Screenshots

| Main Site | NP Site |
|--------|--------|
| <img width="962" alt="Screenshot 2024-03-11 at 8 48 50 AM" src="https://github.com/Good-Bids/goodbids/assets/91974372/96ef0dc8-c6de-46ff-821e-48182b3723f5"> | <img width="669" alt="Screenshot 2024-03-11 at 8 49 15 AM" src="https://github.com/Good-Bids/goodbids/assets/91974372/a7913e29-b32c-4765-a235-24f8121ac3ff"> | 

