### PR TITLE
[#677] Adjust copy on accessibility step for onboarding

### DIFF
--- a/client-mu-plugins/goodbids/src/views/nonprofit-onboarding/steps/activate-accessibility-checker.tsx
+++ b/client-mu-plugins/goodbids/src/views/nonprofit-onboarding/steps/activate-accessibility-checker.tsx
@@ -12,7 +12,7 @@ export function ActivateAccessibilityCheckerStep() {
 				<H1>{__('Activate Accessibility Checker Pro', 'goodbids')}</H1>
 				<P>
 					{__(
-						"All GOODBIDS Nonprofit sites must meet web accessibility guidelines. The Accessibility Checker Pro plugin is required to help you with compliance. Click the button below, then click Activate License to enable the plugin. Leave the license field blank to use the GOODBIDS license key.",
+						'All GOODBIDS Nonprofit sites must meet web accessibility guidelines. The Accessibility Checker Pro plugin is required to help you with compliance. Click the button below, then click Activate License to enable the plugin. Leave the license field blank to use the GOODBIDS license key.',
 						'goodbids',
 					)}
 				</P>


### PR DESCRIPTION
Request from GB team to remove notes from onboarding content re: Nonprofit sites adding their own accessibility checker license key. 