### PR TITLE
[#681] Fix bug when Stripe Customer does not exist.

### DIFF
--- a/client-mu-plugins/goodbids/src/classes/Nonprofits/Stripe.php
+++ b/client-mu-plugins/goodbids/src/classes/Nonprofits/Stripe.php
@@ -255,6 +255,10 @@ class Stripe {
 			$customer_id = $this->get_customer_id();
 		}
 
+		if ( ! $customer_id ) {
+			return null;
+		}
+
 		$customer = goodbids()->sites->main(
 			function() use ( $customer_id ): ?stdClass {
 				try {


### PR DESCRIPTION
# Summary

This PR fixes a bug when a Stripe customer is trying to be fetched before their customer has been created in Stripe.

## Issues

* #681 

## Testing Instructions

1. Log in (or switch to) BDP Admin user
2. Add New Site and fill out Nonprofit Verification form with Primary Contact + Finance Contact, click "Update Details"
3. There should be no Stripe-related errors on the page.
