### PR TITLE
[#673] Hide Fundraising Admin Fields

### DIFF
--- a/client-mu-plugins/goodbids/src/classes/Auctions/Auctions.php
+++ b/client-mu-plugins/goodbids/src/classes/Auctions/Auctions.php
@@ -88,6 +88,12 @@ class Auctions {
 	public array $cron_intervals = [];
 
 	/**
+	 * @since 1.0.0
+	 * @var Wizard
+	 */
+	public Wizard $wizard;
+
+	/**
 	 * Initialize Auctions
 	 *
 	 * @since 1.0.0
@@ -100,6 +106,9 @@ class Auctions {
 
 		// Init Auction Wizard.
 		$this->wizard = new Wizard();
+
+		// Init Fundraising Fields class.
+		new FundraisingFields();
 
 		// Set up Cron Schedules.
 		$this->cron_intervals['1min']  = [

--- a/client-mu-plugins/goodbids/src/classes/Auctions/FundraisingFields.php
+++ b/client-mu-plugins/goodbids/src/classes/Auctions/FundraisingFields.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Auction Fundraising Fields
+ *
+ * @since 1.0.0
+ * @package GoodBids
+ */
+
+namespace GoodBids\Auctions;
+
+/**
+ * Fundraising Fields Class
+ *
+ * @since 1.0.0
+ */
+class FundraisingFields {
+
+	/**
+	 * @since 1.0.0
+	 */
+	public function __construct() {
+		// Removes some ACF fields from the Admin UI.
+		$this->disable_fundraising_fields();
+	}
+
+	/**
+	 * Temporarily Disable some of the Fundraising Auction fields
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return void
+	 */
+	private function disable_fundraising_fields(): void {
+		add_action(
+			'current_screen',
+			function(): void {
+				if ( is_super_admin() ) {
+					return;
+				}
+
+				$screen = get_current_screen();
+				if ( goodbids()->auctions->get_post_type() !== $screen->id ) {
+					return;
+				}
+
+				?>
+				<style>
+					div.acf-field[data-name="estimated_value"],
+					div.acf-field[data-name="auction_goal"],
+					div.acf-field[data-name="expected_high_bid"] {
+						display: none;
+					}
+					div.acf-field[data-name="auction_product"] {
+						width: 100% !important;
+					}
+				</style>
+				<?php
+			}
+		);
+	}
+
+}

--- a/client-mu-plugins/goodbids/src/classes/Auctions/Wizard.php
+++ b/client-mu-plugins/goodbids/src/classes/Auctions/Wizard.php
@@ -188,7 +188,7 @@ class Wizard {
 	 *
 	 * @return void
 	 */
-	public function enqueue_scripts(): void {
+	private function enqueue_scripts(): void {
 		add_filter(
 			'goodbids_admin_script_dependencies',
 			function( array $dependencies ): array {


### PR DESCRIPTION
# Summary

This PR adds some Admin CSS to temporarily hide the Fundraising fields on the Add/Edit Auction page.

## Issues

* #673 

## Testing Instructions

1. Click Edit on an Auction
2. Go to the Auction Settings meta box
3. Verify Estimated Value, Auction Goal, and Expected High Bid fields are not visible.
4. Save changes to the Auction to ensure this data is not lost.

## Screenshots

<img width="843" alt="Screenshot 2024-03-11 at 2 47 24 PM" src="https://github.com/Good-Bids/goodbids/assets/122309362/c9af5edd-c362-4ab6-b09f-edd1dd53a1bb">

<img width="843" alt="Screenshot 2024-03-11 at 2 47 46 PM" src="https://github.com/Good-Bids/goodbids/assets/122309362/50165ebf-9eff-4701-9f80-18c4d4632234">

