### PR TITLE
[#645] Updating the arrow to fix the Jetpack bug

### DIFF
--- a/client-mu-plugins/goodbids/src/assets/css/global-forms.css
+++ b/client-mu-plugins/goodbids/src/assets/css/global-forms.css
@@ -17,6 +17,10 @@
 			@apply rounded border-solid border-base bg-contrast text-base-2 placeholder:text-base focus:outline-contrast-3;
 		}
 
+		.contact-form__select-wrapper:after {
+			@apply !bottom-0 !top-0 !m-auto;
+		}
+
 		.wp-block-button__link {
 			@apply btn-fill-secondary;
 		}


### PR DESCRIPTION
# Summary

Looked into this and found that Jetpack was adding a custom line height onto the select input. Turns out that by editng the input line height messes with the Jetpack CSS. So this is fixing the bug with Jetpacks css to set the arrows in the middle of the input vs going by on the padding of the input. 

## Issues

* #645

## Testing Instructions

1. Creating a form with a select. 
2. Edit the line height of that select. 
3. Make sure the arrow stays in the middle. 

## Screenshots

<img width="1259" alt="Screenshot 2024-03-12 at 8 37 12 AM" src="https://github.com/Good-Bids/goodbids/assets/91974372/58807e06-9441-4679-8921-9486d83f8003">

<img width="825" alt="Screenshot 2024-03-12 at 8 59 50 AM" src="https://github.com/Good-Bids/goodbids/assets/91974372/bbb0bb39-2a28-474b-acab-c4b317e31cd1">
