### PR TITLE
[#473] Updating the site name grid layout for mobile

### DIFF
--- a/client-mu-plugins/goodbids/blocks/site-directory/render.php
+++ b/client-mu-plugins/goodbids/blocks/site-directory/render.php
@@ -16,7 +16,7 @@ endif;
 
 ?>
 <div <?php block_attr( $block, 'my-8' ); ?>>
-	<ul class="grid grid-cols-5 gap-8 p-0 m-0 list-none">
+	<ul class="grid grid-cols-1 gap-8 p-0 m-0 list-none sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-5">
 		<?php
 		goodbids()->sites->loop(
 			function ( $site_id ) {


### PR DESCRIPTION
# Summary

This adds breakpoints for the site grid. 

- Large: 5 columns
- Medium: 3 columns
- Small: 2 columns
- 1 column

## Issues

* #473

## Testing Instructions

1. Go to a page that has the site directory grid.
2. Scale it down from desktop to mobile. 

## Screenshots



https://github.com/Good-Bids/goodbids/assets/91974372/c33c359b-9781-40f5-bcd6-b1fb791932ba




