### PR TITLE
[n/a] Removing light version of smtp plugin

### DIFF
--- a/client-mu-plugins/goodbids/composer.json
+++ b/client-mu-plugins/goodbids/composer.json
@@ -61,7 +61,6 @@
 		"wpackagist-plugin/woocommerce-gateway-stripe": "^8.0",
 		"wpackagist-plugin/woocommerce-services": "^2.5",
 		"wpackagist-plugin/wp-mail-log": "^1.1",
-		"wpackagist-plugin/wp-mail-smtp": "^4.0",
 		"wpackagist-plugin/zapier": "^1.0",
 		"wpengine/advanced-custom-fields-pro": "^6.2"
 	},

--- a/client-mu-plugins/goodbids/composer.lock
+++ b/client-mu-plugins/goodbids/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1a044a6bbd41e83ac2decb6df907ccf8",
+    "content-hash": "0632a885b85981fd1d022bbda8057010",
     "packages": [
         {
             "name": "composer/installers",
@@ -1372,24 +1372,6 @@
             },
             "type": "wordpress-plugin",
             "homepage": "https://wordpress.org/plugins/wp-mail-log/"
-        },
-        {
-            "name": "wpackagist-plugin/wp-mail-smtp",
-            "version": "4.0.1",
-            "source": {
-                "type": "svn",
-                "url": "https://plugins.svn.wordpress.org/wp-mail-smtp/",
-                "reference": "tags/4.0.1"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/wp-mail-smtp.4.0.1.zip"
-            },
-            "require": {
-                "composer/installers": "^1.0 || ^2.0"
-            },
-            "type": "wordpress-plugin",
-            "homepage": "https://wordpress.org/plugins/wp-mail-smtp/"
         },
         {
             "name": "wpackagist-plugin/zapier",

--- a/client-mu-plugins/goodbids/config.json
+++ b/client-mu-plugins/goodbids/config.json
@@ -11,7 +11,6 @@
     "woocommerce",
     "woocommerce-gateway-stripe",
     "woocommerce-services",
-    "wp-mail-smtp/wp_mail_smtp.php",
     "wp-mail-smtp-pro/wp_mail_smtp.php"
   ],
   "post-install-plugins": [


### PR DESCRIPTION
# Summary

Each plugin is different. SMTP does not need the lite version to run the pro version. In fact you can't run them together as it always default to the lite version.  

## Issues

* NA

## Testing Instructions

1. NA
## Screenshots

NA
