### PR TITLE
[#707] Disable save buttons while inflight

### DIFF
--- a/client-mu-plugins/goodbids/src/views/auction-wizard/create/review.tsx
+++ b/client-mu-plugins/goodbids/src/views/auction-wizard/create/review.tsx
@@ -165,6 +165,11 @@ export function ReviewStep({
 		setStep('finish');
 	};
 
+	const loading =
+		createProduct.status === 'pending' ||
+		createAuction.status === 'pending' ||
+		updateAuctionContent.status === 'pending';
+
 	return (
 		<Wrapper
 			progress={90}
@@ -182,8 +187,14 @@ export function ReviewStep({
 					updateStatus={updateAuctionContent.status}
 				/>
 
-				<Button variant="solid" onClick={handleSubmitStart}>
-					{__('Save and continue', 'goodbids')}
+				<Button
+					disabled={loading}
+					variant="solid"
+					onClick={handleSubmitStart}
+				>
+					{loading
+						? __('Saving', 'goodbids')
+						: __('Save my progress', 'goodbids')}
 				</Button>
 			</div>
 		</Wrapper>

--- a/client-mu-plugins/goodbids/src/views/nonprofit-setup-guide/site-status/pending.tsx
+++ b/client-mu-plugins/goodbids/src/views/nonprofit-setup-guide/site-status/pending.tsx
@@ -18,6 +18,8 @@ export function Pending({ manuallySetToLive }: PendingProps) {
 		publishSite.mutate({ site_id: gbNonprofitSetupGuide.siteId });
 	};
 
+	const loading = publishSite.status === 'pending';
+
 	return (
 		<>
 			<H1>{__('Pending', 'goodbids')}</H1>
@@ -55,8 +57,14 @@ export function Pending({ manuallySetToLive }: PendingProps) {
 			</P>
 
 			<div className="w-full max-w-60">
-				<Button variant="solid" onClick={handlePublishSite}>
-					{__('Launch Site', 'goodbids')}
+				<Button
+					disabled={loading}
+					variant="solid"
+					onClick={handlePublishSite}
+				>
+					{loading
+						? __('Saving', 'goodbids')
+						: __('Launch Site', 'goodbids')}
 				</Button>
 			</div>
 


### PR DESCRIPTION
# Summary

- Disables save button on auction wizard while saving is inflight
- Disables "go live" button on pending sites while going live is inflight

## Issues

- #707

## Testing Instructions

1. Go through the auction wizard up to the review step
2. Click the save button
3. Then try to click it again. You can't. It's disabled.
4. Same thing happens on the pending step in the site guide.

## Screenshots

https://github.com/Good-Bids/goodbids/assets/48295174/16f4c1db-962f-497c-a047-992f096863ee
