### PR TITLE
[#561] Updating my account navigation style on mobile

### DIFF
--- a/client-mu-plugins/goodbids/src/assets/css/woocommerce/my-account.css
+++ b/client-mu-plugins/goodbids/src/assets/css/woocommerce/my-account.css
@@ -8,16 +8,20 @@
 	}
 
 	.woocommerce-account {
-		main .woocommerce {
-			@apply !max-w-full;
-		}
-
 		.woocommerce-MyAccount-navigation {
-			@apply w-1/4;
+			@apply w-full border-b-2 border-solid border-x-transparent border-b-contrast border-t-transparent sm:!w-1/4 sm:border-none;
+
+			ul {
+				@apply flex flex-wrap gap-x-8 gap-y-2 text-sm sm:block sm:text-md;
+			}
 
 			.woocommerce-MyAccount-navigation-link {
-				@apply py-2;
+				@apply !py-2;
 			}
+		}
+
+		main .woocommerce {
+			@apply !max-w-full;
 		}
 
 		.woocommerce-MyAccount-content {

--- a/client-mu-plugins/goodbids/views/woocommerce/myaccount/dashboard-header.php
+++ b/client-mu-plugins/goodbids/views/woocommerce/myaccount/dashboard-header.php
@@ -23,7 +23,7 @@ use GoodBids\Auctions\Bids;
 
 		<li class="w-full p-4 text-base rounded-sm sm:w-auto bg-contrast">
 			<p class="m-0 font-thin uppercase has-x-small-font-size"><?php esc_html_e( 'Free Bids', 'goodbids' ); ?></p>
-			<div class="flex items-center justify-between">
+			<div class="flex flex-wrap items-center justify-between gap-3">
 				<p class="mt-2 mb-0 text-lg font-bold"><?php echo esc_html( count( goodbids()->users->get_free_bids( null, Bids::FREE_BID_STATUS_UNUSED ) ) ); ?></p>
 				<a class="px-3 py-1 btn-fill-secondary" href="<?php echo esc_url( wc_get_account_endpoint_url( 'dashboard' ) . 'my-referrals/' ); ?>"><?php esc_html_e( 'Earn more', 'goodbids' ); ?></a>
 			</div>


### PR DESCRIPTION
# Summary

This updates the navigation on mobile so it does not take as much space. The menu items have the right amount of space to pass a11y. 

@shascher The ticket has a note about adding an anchor link but that would take a bit of effort which would require us to rebuild the main file that shows the My Account content. If we do have the time it may be better to rebuild the navigation to be a hide/show toggle. 

## Issues

* #561

## Testing Instructions

1. Go to the My Account page on mobile. 
2. Make sure the navigation is smaller and stacked. 

## Screenshots

iPhone SE
<img width="377" alt="Screenshot 2024-03-12 at 3 19 41 PM" src="https://github.com/Good-Bids/goodbids/assets/91974372/f69641ca-5ace-4030-a11c-7e1024b4ff7f">

