### PR TITLE
[#714] Bidding Block Framer Issue

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,8 +22,7 @@ jobs:
       - run: echo "Building..."
       - run: echo "${ACF_DEVELOP}" >> ./client-mu-plugins/goodbids/auth.json
       - run: echo "$(< ./client-mu-plugins/goodbids/auth.json)"
-      - run: cd client-mu-plugins/goodbids && rm package-lock.json
-      - run: cd client-mu-plugins/goodbids && npm install
+      - run: cd client-mu-plugins/goodbids && npm ci
       - run: cd client-mu-plugins/goodbids && npm run build
       - run: cd client-mu-plugins/goodbids && composer install --verbose
 


### PR DESCRIPTION
# Summary

- Uses `npm ci` instead of `npm install`

Sadly, past Nick didn't record why he was doing this. I think there was an issue with `npm ci` failing, but it looks good now.

Either way, this bug was caused by an issue with Framer Motion. Seems like 11.0.12 introduced a bug. This should keep it at the working version of 11.0.3.

## Issues

- #714

## Testing Instructions

1. Go to a bunch of auctions
2. See that they're all working
