### PR TITLE
[#732] Disable WC Customer Completed Order Email

### DIFF
--- a/client-mu-plugins/goodbids/src/classes/Plugins/WooCommerce/Emails.php
+++ b/client-mu-plugins/goodbids/src/classes/Plugins/WooCommerce/Emails.php
@@ -56,6 +56,9 @@ class Emails {
 
 		// Disable Processing Order Emails
 		$this->disable_processing_order_emails();
+
+		// Disable Order Completed Emails
+		$this->disable_order_completed_emails();
 	}
 
 	/**
@@ -216,6 +219,32 @@ class Emails {
 			'woocommerce_email_get_option',
 			function ( mixed $value, \WC_Email $email, mixed $original_value, string $key ) {
 				if ( 'customer_processing_order' !== $email->id || 'enabled' !== $key ) {
+					return $value;
+				}
+
+				$email->form_fields['enabled']['default'] = 'no';
+
+				return 'no';
+			},
+			10,
+			4
+		);
+	}
+
+	/**
+	 * Disable Order Completed Emails
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return void
+	 */
+	private function disable_order_completed_emails(): void {
+		add_filter( 'woocommerce_enabled_customer_completed_order', '__return_false' );
+
+		add_filter(
+			'woocommerce_email_get_option',
+			function ( mixed $value, \WC_Email $email, mixed $original_value, string $key ) {
+				if ( 'customer_completed_order' !== $email->id || 'enabled' !== $key ) {
 					return $value;
 				}
 


### PR DESCRIPTION
# Summary

This PR disabled the WooCommerce Customer Completed Order Email by default.

## Issues

* #732 

## Testing Instructions

1. As Super Admin, on a Nonprofit site:
2. Go to WP Admin > WooCommerce > Settings > Emails
3. Verify Completed Order email is disabled.
4. Place a bid and make sure you don't get the Completed Order email.

## Screenshots

<img width="681" alt="Screenshot 2024-03-14 at 10 38 28 AM" src="https://github.com/Good-Bids/goodbids/assets/122309362/f92a9bf1-8cbe-4f14-81b2-69841c927020">

