### PR TITLE
[#743] Fix Accessibility Double Click bug

### DIFF
--- a/client-mu-plugins/goodbids/src/classes/Nonprofits/Onboarding.php
+++ b/client-mu-plugins/goodbids/src/classes/Nonprofits/Onboarding.php
@@ -706,26 +706,28 @@ class Onboarding {
 
 				$skip_step = $this->get_skip_step();
 
-				if ( ! $skip_step ) {
-					$current     = $this->get_current_step();
-					$current_key = $this->get_current_step_key();
+				// Handle Skipped Steps.
+				if ( $skip_step ) {
+					if ( $skip_step === $this->get_current_step_key() && $this->skip_step() ) {
+						$next_key = $this->get_next_step_key();
 
-					// Skip to the first incomplete step.
-					if ( $current['is_complete'] ) {
-						$this->handle_step_completed( $current_key );
+						if ( $next_key ) {
+							$this->set_step_transient( $next_key );
+							wp_safe_redirect( $this->get_url( $next_key ) );
+							exit;
+						}
 					}
 
 					return;
 				}
 
-				if ( $skip_step === $this->get_current_step_key() && $this->skip_step() ) {
-					$next_key = $this->get_next_step_key();
+				// Move to the next step if the current step is complete.
+				$current     = $this->get_current_step();
+				$current_key = $this->get_current_step_key();
 
-					if ( $next_key ) {
-						$this->set_step_transient( $next_key );
-						wp_safe_redirect( $this->get_url( $next_key ) );
-						exit;
-					}
+				// Skip to the first incomplete step.
+				if ( $current['is_complete'] ) {
+					$this->handle_step_completed( $current_key );
 				}
 			},
 			40
@@ -820,7 +822,9 @@ class Onboarding {
 			return;
 		}
 
-		$redirect = $this->get_url( $this->get_next_step_key() );
+		$next_key = $this->get_next_step_key();
+		$redirect = $this->get_url( $next_key );
+		$this->set_step_transient( $next_key );
 		wp_safe_redirect( $redirect );
 		exit;
 	}

--- a/client-mu-plugins/goodbids/src/views/nonprofit-onboarding/steps/activate-accessibility-checker.tsx
+++ b/client-mu-plugins/goodbids/src/views/nonprofit-onboarding/steps/activate-accessibility-checker.tsx
@@ -1,6 +1,6 @@
 import { __ } from '@wordpress/i18n';
-import { ButtonLink } from '../../../components/button-link';
-import { H1, P } from '../../../components/typography';
+import { ButtonLink } from '~/components/button-link';
+import { H1, P } from '~/components/typography';
 import { PuzzleManImage } from '~/components/images/puzzle-man';
 import { Wrapper } from '../wrapper';
 

--- a/client-mu-plugins/goodbids/src/views/nonprofit-onboarding/steps/create-store.tsx
+++ b/client-mu-plugins/goodbids/src/views/nonprofit-onboarding/steps/create-store.tsx
@@ -1,6 +1,6 @@
 import { __ } from '@wordpress/i18n';
-import { ButtonLink } from '../../../components/button-link';
-import { H1, P } from '../../../components/typography';
+import { ButtonLink } from '~/components/button-link';
+import { H1, P } from '~/components/typography';
 import { PuzzleManImage } from '~/components/images/puzzle-man';
 import { Wrapper } from '../wrapper';
 


### PR DESCRIPTION
# Summary

This PR fixes a bug when clicking on a steps action sometimes requires a 2nd click.

## Issues

* #743 

## Testing Instructions

1. Create a new Nonprofit Site
2. Visit the NP Dashboard > Onboarding Wizard
3. Ensure only 1 click is necessary on the Accessibility Activation Step
