### PR TITLE
[#728] Removing the font-thin class

### DIFF
--- a/client-mu-plugins/goodbids/views/woocommerce/myaccount/dashboard-header.php
+++ b/client-mu-plugins/goodbids/views/woocommerce/myaccount/dashboard-header.php
@@ -12,17 +12,17 @@ use GoodBids\Auctions\Bids;
 <div class="mb-6 first-line:goodbids-auctions-header">
 	<ul class="flex flex-wrap gap-6 p-0 m-0 list-none md:grid md:grid-cols-3 goodbids-order-metrics">
 		<li class="w-full p-4 rounded-sm sm:w-auto bg-contrast-5">
-			<p class="m-0 font-thin uppercase has-x-small-font-size"><?php esc_html_e( 'Total Donated', 'goodbids' ); ?></p>
+			<p class="m-0 uppercase has-x-small-font-size"><?php esc_html_e( 'Total Donated', 'goodbids' ); ?></p>
 			<p class="mt-2 mb-0 text-lg font-bold"><?php echo wp_kses_post( wc_price( goodbids()->sites->get_user_total_donated() ) ); ?></p>
 		</li>
 
 		<li class="w-full p-4 rounded-sm sm:w-auto bg-contrast-5">
-			<p class="m-0 font-thin uppercase has-x-small-font-size"><?php esc_html_e( 'Nonprofits Supported', 'goodbids' ); ?></p>
+			<p class="m-0 uppercase has-x-small-font-size"><?php esc_html_e( 'Nonprofits Supported', 'goodbids' ); ?></p>
 			<p class="mt-2 mb-0 text-lg font-bold"><?php echo esc_html( goodbids()->sites->get_user_nonprofits_supported() ); ?></p>
 		</li>
 
 		<li class="w-full p-4 text-base rounded-sm sm:w-auto bg-contrast">
-			<p class="m-0 font-thin uppercase has-x-small-font-size"><?php esc_html_e( 'Free Bids', 'goodbids' ); ?></p>
+			<p class="m-0 uppercase has-x-small-font-size"><?php esc_html_e( 'Free Bids', 'goodbids' ); ?></p>
 			<div class="flex flex-wrap items-center justify-between gap-3">
 				<p class="mt-2 mb-0 text-lg font-bold"><?php echo esc_html( count( goodbids()->users->get_free_bids( null, Bids::FREE_BID_STATUS_UNUSED ) ) ); ?></p>
 				<a class="px-3 py-1 btn-fill-secondary" href="<?php echo esc_url( wc_get_account_endpoint_url( 'dashboard' ) . 'my-referrals/' ); ?>"><?php esc_html_e( 'Earn more', 'goodbids' ); ?></a>

--- a/client-mu-plugins/goodbids/views/woocommerce/myaccount/free-bids-header.php
+++ b/client-mu-plugins/goodbids/views/woocommerce/myaccount/free-bids-header.php
@@ -12,17 +12,17 @@ use GoodBids\Auctions\Bids;
 <div class="mb-6 first-line:goodbids-auctions-header">
 	<ul class="flex flex-wrap gap-6 p-0 m-0 list-none md:grid md:grid-cols-3 goodbids-order-metrics">
 		<li class="w-full p-4 rounded-sm sm:w-auto bg-contrast-5">
-			<p class="m-0 font-thin uppercase has-x-small-font-size"><?php esc_html_e( 'Available', 'goodbids' ); ?></p>
+			<p class="m-0 uppercase has-x-small-font-size"><?php esc_html_e( 'Available', 'goodbids' ); ?></p>
 			<p class="mt-2 mb-0 text-lg font-bold"><?php echo esc_html( count( goodbids()->users->get_free_bids( null, Bids::FREE_BID_STATUS_UNUSED ) ) ); ?></p>
 		</li>
 
 		<li class="w-full p-4 rounded-sm sm:w-auto bg-contrast-5">
-			<p class="m-0 font-thin uppercase has-x-small-font-size"><?php esc_html_e( 'Earned', 'goodbids' ); ?></p>
+			<p class="m-0 uppercase has-x-small-font-size"><?php esc_html_e( 'Earned', 'goodbids' ); ?></p>
 			<p class="mt-2 mb-0 text-lg font-bold"><?php echo esc_html( count( goodbids()->users->get_free_bids() ) ); ?></p>
 		</li>
 
 		<li class="w-full p-4 rounded-sm sm:w-auto bg-contrast-5">
-			<p class="m-0 font-thin uppercase has-x-small-font-size"><?php esc_html_e( 'Used', 'goodbids' ); ?></p>
+			<p class="m-0 uppercase has-x-small-font-size"><?php esc_html_e( 'Used', 'goodbids' ); ?></p>
 			<p class="mt-2 mb-0 text-lg font-bold"><?php echo esc_html( count( goodbids()->users->get_free_bids( null, Bids::FREE_BID_STATUS_USED ) ) ); ?></p>
 		</li>
 	</ul>

--- a/client-mu-plugins/goodbids/views/woocommerce/myaccount/my-auctions-header.php
+++ b/client-mu-plugins/goodbids/views/woocommerce/myaccount/my-auctions-header.php
@@ -11,17 +11,17 @@
 
 	<ul class="flex flex-wrap gap-6 p-0 m-0 list-none md:grid md:grid-cols-3 goodbids-order-metrics">
 		<li class="w-full p-4 rounded-sm sm:w-auto bg-contrast-5">
-			<p class="m-0 font-thin uppercase has-x-small-font-size"><?php esc_html_e( 'Total Auctions', 'goodbids' ); ?></p>
+			<p class="m-0 uppercase has-x-small-font-size"><?php esc_html_e( 'Total Auctions', 'goodbids' ); ?></p>
 			<p class="mt-2 mb-0 text-lg font-bold"><?php echo esc_html( count( goodbids()->sites->get_user_participating_auctions() ) ); ?></p>
 		</li>
 
 		<li class="w-full p-4 rounded-sm sm:w-auto bg-contrast-5">
-			<p class="m-0 font-thin uppercase has-x-small-font-size"><?php esc_html_e( 'Live Auctions', 'goodbids' ); ?></p>
+			<p class="m-0 uppercase has-x-small-font-size"><?php esc_html_e( 'Live Auctions', 'goodbids' ); ?></p>
 			<p class="mt-2 mb-0 text-lg font-bold"><?php echo esc_html( count( goodbids()->sites->get_user_live_participating_auctions() ) ); ?></p>
 		</li>
 
 		<li class="w-full p-4 rounded-sm sm:w-auto bg-contrast-5">
-			<p class="m-0 font-thin uppercase has-x-small-font-size"><?php esc_html_e( 'Auctions Won', 'goodbids' ); ?></p>
+			<p class="m-0 uppercase has-x-small-font-size"><?php esc_html_e( 'Auctions Won', 'goodbids' ); ?></p>
 			<p class="mt-2 mb-0 text-lg font-bold"><?php echo esc_html( count( goodbids()->sites->get_user_auctions_won() ) ); ?></p>
 		</li>
 	</ul>

--- a/client-mu-plugins/goodbids/views/woocommerce/myaccount/my-rewards-header.php
+++ b/client-mu-plugins/goodbids/views/woocommerce/myaccount/my-rewards-header.php
@@ -13,17 +13,17 @@ $unclaimed = $earned - $claimed;
 <div class="mb-6 goodbids-rewards-header">
 	<ul class="flex flex-wrap gap-6 p-0 m-0 list-none md:grid md:grid-cols-3 goodbids-order-metrics">
 		<li class="w-full p-4 rounded-sm sm:w-auto bg-contrast-5">
-			<p class="m-0 font-thin uppercase has-x-small-font-size"><?php esc_html_e( 'Earned', 'goodbids' ); ?></p>
+			<p class="m-0 uppercase has-x-small-font-size"><?php esc_html_e( 'Earned', 'goodbids' ); ?></p>
 			<p class="mt-2 mb-0 text-lg font-bold"><?php echo esc_html( $earned ); ?></p>
 		</li>
 
 		<li class="w-full p-4 rounded-sm sm:w-auto bg-contrast-5">
-			<p class="m-0 font-thin uppercase has-x-small-font-size"><?php esc_html_e( 'Claimed', 'goodbids' ); ?></p>
+			<p class="m-0 uppercase has-x-small-font-size"><?php esc_html_e( 'Claimed', 'goodbids' ); ?></p>
 			<p class="mt-2 mb-0 text-lg font-bold"><?php echo esc_html( $claimed ); ?></p>
 		</li>
 
 		<li class="w-full p-4 rounded-sm sm:w-auto bg-contrast-5">
-			<p class="m-0 font-thin uppercase has-x-small-font-size"><?php esc_html_e( 'Unclaimed', 'goodbids' ); ?></p>
+			<p class="m-0 uppercase has-x-small-font-size"><?php esc_html_e( 'Unclaimed', 'goodbids' ); ?></p>
 			<p class="mt-2 mb-0 text-lg font-bold"><?php echo esc_html( $unclaimed ); ?></p>
 		</li>
 	</ul>

--- a/client-mu-plugins/goodbids/views/woocommerce/myaccount/orders-header.php
+++ b/client-mu-plugins/goodbids/views/woocommerce/myaccount/orders-header.php
@@ -10,17 +10,17 @@
 <div class="mb-6 goodbids-orders-header">
 	<ul class="flex flex-wrap gap-6 p-0 m-0 list-none md:grid md:grid-cols-3 goodbids-order-metrics">
 		<li class="w-full p-4 rounded-sm sm:w-auto bg-contrast-5">
-			<p class="m-0 font-thin uppercase has-x-small-font-size"><?php esc_html_e( 'Total Bids', 'goodbids' ); ?></p>
+			<p class="m-0 uppercase has-x-small-font-size"><?php esc_html_e( 'Total Bids', 'goodbids' ); ?></p>
 			<p class="mt-2 mb-0 text-lg font-bold"><?php echo esc_html( goodbids()->sites->get_user_total_bids() ); ?></p>
 		</li>
 
 		<li class="w-full p-4 rounded-sm sm:w-auto bg-contrast-5">
-			<p class="m-0 font-thin uppercase has-x-small-font-size"><?php esc_html_e( 'Total Donated', 'goodbids' ); ?></p>
+			<p class="m-0 uppercase has-x-small-font-size"><?php esc_html_e( 'Total Donated', 'goodbids' ); ?></p>
 			<p class="mt-2 mb-0 text-lg font-bold"><?php echo wp_kses_post( wc_price( goodbids()->sites->get_user_total_donated() ) ); ?></p>
 		</li>
 
 		<li class="w-full p-4 rounded-sm sm:w-auto bg-contrast-5">
-			<p class="m-0 font-thin uppercase has-x-small-font-size"><?php esc_html_e( 'Nonprofits Supported', 'goodbids' ); ?></p>
+			<p class="m-0 uppercase has-x-small-font-size"><?php esc_html_e( 'Nonprofits Supported', 'goodbids' ); ?></p>
 			<p class="mt-2 mb-0 text-lg font-bold"><?php echo esc_html( goodbids()->sites->get_user_nonprofits_supported() ); ?></p>
 		</li>
 	</ul>


### PR DESCRIPTION
# Summary

Removes the class `font-thin` from the dashboard grid text. 

## Issues

* #728

## Testing Instructions

1. Go to the My Account and make sure the header grid text is not thin.

## Screenshots

<img width="897" alt="Screenshot 2024-03-14 at 12 43 15 PM" src="https://github.com/Good-Bids/goodbids/assets/91974372/ee9501e6-59d3-4e58-a831-3722f18e9883">
