### PR TITLE
[#602] Auto-enable SSO for new Nonprofits when they're verified

### DIFF
--- a/client-mu-plugins/goodbids/src/classes/Core.php
+++ b/client-mu-plugins/goodbids/src/classes/Core.php
@@ -33,6 +33,7 @@ use GoodBids\Partners\Partners;
 use GoodBids\Plugins\ACF;
 use GoodBids\Plugins\EarlyHooks;
 use GoodBids\Plugins\EqualizeDigital;
+use GoodBids\Plugins\MiniOrange;
 use GoodBids\Plugins\OneTrust;
 use GoodBids\Plugins\WooCommerce;
 use GoodBids\Users\Permissions;
@@ -288,6 +289,10 @@ class Core {
 		if ( file_exists( $local_json ) ) {
 			$local = json_decode( file_get_contents( $local_json ), true ); // phpcs:ignore
 			if ( is_array( $local ) ) {
+				if ( empty( $local['version'] ) || version_compare( $json['version'], $local['version'], '!=' ) ) {
+					Log::warning( 'Local config file version mismatch.' );
+				}
+
 				$json = array_merge_recursive( $json, $local );
 			}
 		}
@@ -505,6 +510,7 @@ class Core {
 				new OneTrust();
 				new Guide();
 				new NonprofitAdmin();
+				new MiniOrange();
 			}
 		);
 	}

--- a/client-mu-plugins/goodbids/src/classes/Plugins/MiniOrange.php
+++ b/client-mu-plugins/goodbids/src/classes/Plugins/MiniOrange.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * miniOrange OAuth SSO plugin settings
+ *
+ * @since 1.0.0
+ * @package GoodBids
+ */
+
+namespace GoodBids\Plugins;
+
+use GoodBids\Utilities\Log;
+
+/**
+ * This class handles SSO settings.
+ *
+ * @since 1.0.0
+ */
+class MiniOrange {
+
+	/**
+	 * @since 1.0.0
+	 * @var string
+	 */
+	private string $slug = 'miniorange-oauth-oidc-single-sign-on/mo_oauth_settings.php';
+
+	/**
+	 * Initialize the class.
+	 *
+	 * @since 1.0.0
+	 */
+	public function __construct() {
+		if ( ! goodbids()->is_plugin_active( $this->slug ) ) {
+			return;
+		}
+
+		// Enable SSO for Nonprofit on Verification.
+		$this->enable_sso_on_verification();
+	}
+
+	/**
+	 * Enable SSO for Nonprofit on Verification.
+	 *
+	 * @return void
+	 *
+	 * @since 1.0.0
+	 */
+	private function enable_sso_on_verification(): void {
+		add_action(
+			'goodbids_nonprofit_verified',
+			function ( int $site_id ) {
+				if ( $site_id === get_main_site_id() ) {
+					return;
+				}
+
+				/*
+				 Sample Data (array of Site IDs):
+				array(16) {
+				  [0]=>
+				  string(2) "40"
+				  [1]=>
+				  string(2) "44"
+				  [2]=>
+				  string(2) "30"
+				  ...
+				}
+				*/
+
+				// Table: wp_sitemeta
+				// Site ID: 1 (main site)
+
+				// Option Name: mo_oauth_c3Vic2l0ZXNzZWxlY3RlZA
+				// Sample Encrypted Value: 1XCthJdfi6GVjHyJmJRnnZyCrHahVZuhg5ZynIeQZ6WcepuHqVWVj5OjcpOHlWednIWbgJdloY+NjIOch5BnpKxwpXapbIuZg5+AicI=
+
+				// Source: plugins/miniorange-oauth-oidc-single-sign-on/classes/Premium/Multisite/class-multisitesettings.php
+				// Method: save_multisite_settings
+				// Encoded Option Name: Look for $Yh->mo_oauth_client_update_option() in the method
+
+				// Decrypt: json_decode( ( new MOUtils() )->mooauthdecrypt( $value ) )
+				// Encrypt: $Yh->mooauthencrypt( json_encode( $value ) )
+
+				// Class: MOUtils
+				// Path: plugins/miniorange-oauth-oidc-single-sign-on/classes/common/class-moutils.php
+				// Access: global $Yh;
+
+				global $Yh;
+
+				$no_of_sites_key = 'noOfSubSites';
+				$no_of_sites     = intval( $Yh->mo_oauth_client_get_option($no_of_sites_key ) );
+
+				$option_key = 'mo_oauth_c3Vic2l0ZXNzZWxlY3RlZA';
+				$original   = get_site_meta( get_main_site_id(), $option_key, true );
+				$sites      = json_decode( $Yh->mooauthdecrypt( $original ) );
+
+				if ( in_array( (string) $site_id, $sites, true ) ) {
+					return;
+				}
+
+				if ( count( $sites ) + 1 > $no_of_sites ) {
+					Log::warning( 'You have reached the limit of sub-sites allowed for SSO.' );
+					return;
+				}
+
+				$sites[] = (string) $site_id;
+				$updated = $Yh->mooauthencrypt( json_encode( $sites ) ); // phpcs:ignore
+
+				update_site_meta( get_main_site_id(), $option_key, $updated );
+
+				// :crossed_fingers:
+			}
+		);
+	}
+}


### PR DESCRIPTION
# Summary

This PR automatically enables SSO for new Nonprofits after they have been verified.

## Issues

* #602 

## Testing Instructions

1. Create a new Nonprofit Site
2. Visit Network Admin > MiniOrange > Multisite Settings
3. Verify the new site is NOT checked in the list.
4. As a Super Admin, mark the "Verified" _checkbox_ on the Nonprofit Verification detail page.
5. Go back to Network Admin > MiniOrange > Multisite Settings
6. Verify the new site IS checked in the list.