### PR TITLE
[#731] My Account > Bids, plus Pagination Fix

### DIFF
--- a/client-mu-plugins/goodbids/src/classes/Plugins/WooCommerce/Account.php
+++ b/client-mu-plugins/goodbids/src/classes/Plugins/WooCommerce/Account.php
@@ -23,6 +23,11 @@ class Account {
 	/**
 	 * @since 1.0.0
 	 */
+	const BIDS_SLUG = 'bids';
+
+	/**
+	 * @since 1.0.0
+	 */
 	const AUCTIONS_SLUG = 'my-auctions';
 
 	/**
@@ -50,20 +55,23 @@ class Account {
 		 * Note: Tabs will be added in reverse order.
 		 */
 
-		// 4. Custom My Account > Referrals page.
+		// 5. Custom My Account > Referrals page.
 		$this->add_referrals_tab();
 
-		// 3. Custom My Account > Rewards page.
+		// 4. Custom My Account > Rewards page.
 		$this->add_rewards_tab();
 
-		// 2. Custom My Account > Free Bids page.
+		// 3. Custom My Account > Free Bids page.
 		$this->add_free_bids_tab();
 
-		// 1. Custom My Account > Auctions page.
-		$this->add_my_auctions_tab();
+		// 2. Custom My Account > Auctions page.
+		$this->add_auctions_tab();
 
-		// 0. Rename "Orders" to "Bids"
-		$this->rename_orders_tab();
+		// 1. Custom My Account > Bids page.
+		$this->add_bids_tab();
+
+		// 0. Remove "Orders" tab
+		$this->remove_orders_tab();
 
 		// Remove "Order Again" button
 		$this->remove_order_again_button();
@@ -73,6 +81,59 @@ class Account {
 
 		// Remove Download Link
 		$this->remove_download_link();
+	}
+
+	/**
+	 * Create a new Bids tab on My Account page
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return void
+	 */
+	private function add_bids_tab(): void {
+		add_filter(
+			'goodbids_account_' . self::BIDS_SLUG . '_args',
+			function ( $args ) {
+				$bid_orders   = goodbids()->sites->get_user_bid_orders();
+				$total_orders = count( $bid_orders );
+				$current_page = max( intval( get_query_var( self::BIDS_SLUG ) ), 1 );
+
+				// Pagination
+				$max_per_page = goodbids()->get_config( 'woocommerce.account.default-orders-per-page' );
+				$max_pages    = ceil( $total_orders / $max_per_page );
+				$offset       = ( $current_page - 1 ) * $max_per_page;
+				$bid_orders   = array_slice( $bid_orders, $offset, $max_per_page );
+
+				$args['bid_orders']   = $bid_orders;
+				$args['current_page'] = $current_page;
+				$args['has_orders']   = 0 < $total_orders;
+				$args['total_orders'] = $total_orders;
+				$args['max_pages']    = $max_pages;
+
+				return $args;
+			}
+		);
+
+		$this->init_new_account_page( self::BIDS_SLUG, __( 'Bids', 'goodbids' ) );
+	}
+
+	/**
+	 * Create a new Auctions tab on My Account page
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return void
+	 */
+	private function add_auctions_tab(): void {
+		add_filter(
+			'goodbids_account_' . self::AUCTIONS_SLUG . '_args',
+			function ( $args ) {
+				$args['auctions'] = goodbids()->sites->get_user_participating_auctions();
+				return $args;
+			}
+		);
+
+		$this->init_new_account_page( self::AUCTIONS_SLUG, __( 'Auctions', 'goodbids' ) );
 	}
 
 	/**
@@ -95,43 +156,31 @@ class Account {
 	}
 
 	/**
-	 * Create a new Auctions tab on My Account page
-	 *
-	 * @since 1.0.0
-	 *
-	 * @return void
-	 */
-	private function add_my_auctions_tab(): void {
-		add_filter(
-			'goodbids_account_' . self::AUCTIONS_SLUG . '_args',
-			function ( $args ) {
-				$args['auctions'] = goodbids()->sites->get_user_participating_auctions();
-				return $args;
-			}
-		);
-
-		$this->init_new_account_page( self::AUCTIONS_SLUG, __( 'Auctions', 'goodbids' ) );
-	}
-
-	/**
 	 * Create a new Rewards tab on My Account page
 	 *
 	 * @since 1.0.0
 	 *
-	 * @param int $current_page Current page number.
-	 *
 	 * @return void
 	 */
-	private function add_rewards_tab( int $current_page = 1 ): void {
+	private function add_rewards_tab(): void {
 		add_filter(
 			'goodbids_account_' . self::REWARDS_SLUG . '_args',
-			function ( $args ) use ( $current_page ) {
+			function ( $args ) {
 				$reward_orders = goodbids()->sites->get_user_reward_orders();
+				$total_orders  = count( $reward_orders );
+				$current_page = max( intval( get_query_var( self::REWARDS_SLUG ) ), 1 );
 
-				$args['reward_orders']   = $reward_orders;
-				$args['current_page']    = empty( $current_page ) ? 1 : absint( $current_page );
-				$args['has_orders']      = 0 < count( $reward_orders );
-				$args['wp_button_class'] = wc_wp_theme_get_element_class_name( 'button' ) ? ' ' . wc_wp_theme_get_element_class_name( 'button' ) : '';
+				// Pagination
+				$max_per_page  = goodbids()->get_config( 'woocommerce.account.default-orders-per-page' );
+				$max_pages     = ceil( $total_orders / $max_per_page );
+				$offset        = ( $current_page - 1 ) * $max_per_page;
+				$reward_orders = array_slice( $reward_orders, $offset, $max_per_page );
+
+				$args['reward_orders'] = $reward_orders;
+				$args['current_page']  = $current_page;
+				$args['has_orders']    = 0 < $total_orders;
+				$args['total_orders']  = $total_orders;
+				$args['max_pages']     = $max_pages;
 
 				return $args;
 			}
@@ -202,7 +251,7 @@ class Account {
 				foreach ( $items as $key => $value ) {
 					$new_items[ $key ] = $value;
 
-					if ( 'orders' === $key ) {
+					if ( 'dashboard' === $key ) {
 						$new_items[ $slug ] = $label;
 					}
 				}
@@ -228,17 +277,17 @@ class Account {
 	}
 
 	/**
-	 * Rename the Orders tab to Bids.
+	 * Remove the Orders tab in lieu of custom Bids tab.
 	 *
 	 * @since 1.0.0
 	 *
 	 * @return void
 	 */
-	private function rename_orders_tab(): void {
+	private function remove_orders_tab(): void {
 		add_filter(
 			'woocommerce_account_menu_items',
 			function ( $items ) {
-				$items['orders'] = __( 'Bids', 'goodbids' );
+				unset( $items['orders'] );
 				return $items;
 			}
 		);
@@ -272,7 +321,7 @@ class Account {
 			'paginate' => false,
 		];
 
-		return wc_get_orders( array_merge( $args, $query_args ) );
+		return wc_get_orders( array_merge_recursive( $args, $query_args ) );
 	}
 
 	/**

--- a/client-mu-plugins/goodbids/views/woocommerce/myaccount/bids-header.php
+++ b/client-mu-plugins/goodbids/views/woocommerce/myaccount/bids-header.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * GoodBids My Account > Bids Header
+ *
+ * @since 1.0.0
+ * @package GoodBids
+ */
+
+?>
+<div class="mb-6 goodbids-orders-header">
+	<ul class="flex flex-wrap gap-6 p-0 m-0 list-none md:grid md:grid-cols-3 goodbids-order-metrics">
+		<li class="w-full p-4 rounded-sm sm:w-auto bg-contrast-5">
+			<p class="m-0 uppercase has-x-small-font-size"><?php esc_html_e( 'Total Bids', 'goodbids' ); ?></p>
+			<p class="mt-2 mb-0 text-lg font-bold"><?php echo esc_html( goodbids()->sites->get_user_total_bids() ); ?></p>
+		</li>
+
+		<li class="w-full p-4 rounded-sm sm:w-auto bg-contrast-5">
+			<p class="m-0 uppercase has-x-small-font-size"><?php esc_html_e( 'Total Donated', 'goodbids' ); ?></p>
+			<p class="mt-2 mb-0 text-lg font-bold"><?php echo wp_kses_post( wc_price( goodbids()->sites->get_user_total_donated() ) ); ?></p>
+		</li>
+
+		<li class="w-full p-4 rounded-sm sm:w-auto bg-contrast-5">
+			<p class="m-0 uppercase has-x-small-font-size"><?php esc_html_e( 'Nonprofits Supported', 'goodbids' ); ?></p>
+			<p class="mt-2 mb-0 text-lg font-bold"><?php echo esc_html( goodbids()->sites->get_user_nonprofits_supported() ); ?></p>
+		</li>
+	</ul>
+</div>

--- a/client-mu-plugins/goodbids/views/woocommerce/myaccount/bids.php
+++ b/client-mu-plugins/goodbids/views/woocommerce/myaccount/bids.php
@@ -1,0 +1,149 @@
+<?php
+/**
+ * Bid Orders
+ *
+ * Shows Bid orders on the account page.
+ *
+ * @var array $bid_orders
+ * @var bool  $has_orders
+ * @var int   $current_page
+ * @var int   $total_orders
+ * @var int   $max_pages
+ *
+ * @see https://woo.com/document/template-structure/
+ * @package WooCommerce\Templates
+ * @version 8.5.0
+ */
+
+use GoodBids\Plugins\WooCommerce\Account;
+
+defined( 'ABSPATH' ) || exit;
+
+do_action( 'woocommerce_before_account_orders', $has_orders ); ?>
+
+<?php if ( $has_orders ) : ?>
+	<h1><?php esc_html_e( 'Bids', 'goodbids' ); ?></h1>
+
+	<?php goodbids()->load_view( 'woocommerce/myaccount/bids-header.php' ); ?>
+
+	<h2 class="mt-12 font-normal text-md"><?php esc_html_e( 'Donation History', 'goodbids' ); ?></h2>
+
+	<div class="overflow-hidden border border-solid rounded-sm border-black-100">
+		<table class="!mb-0 !border-0 bg-base-2 woocommerce-orders-table woocommerce-MyAccount-orders shop_table shop_table_responsive my_account_orders account-orders-table">
+			<thead>
+				<tr class="bg-base-3">
+					<th class="woocommerce-orders-table__header woocommerce-orders-table__header-donation"><span class="nobr"><?php esc_html_e( 'Donation', 'goodbids' ); ?></span></th>
+					<th class="woocommerce-orders-table__header woocommerce-orders-table__header-nonprofit"><span class="nobr"><?php esc_html_e( 'Nonprofit', 'goodbids' ); ?></span></th>
+					<th class="woocommerce-orders-table__header woocommerce-orders-table__header-total"><span class="nobr"><?php esc_html_e( 'Total', 'goodbids' ); ?></span></th>
+					<th class="woocommerce-orders-table__header woocommerce-orders-table__header-date"><span class="nobr"><?php esc_html_e( 'Date', 'goodbids' ); ?></span></th>
+					<th class="woocommerce-orders-table__header woocommerce-orders-table__header-actions"><span class="sr-only"><?php esc_html_e( 'Actions', 'goodbids' ); ?></span></th>
+				</tr>
+			</thead>
+
+			<tbody>
+				<?php
+				foreach ( $bid_orders as $bid_order ) :
+					goodbids()->sites->swap(
+						function () use ( $bid_order ) {
+							$order = wc_get_order( $bid_order['order_id'] ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+							$auction_id = goodbids()->woocommerce->orders->get_auction_id( $order->get_id() );
+							$auction    = goodbids()->auctions->get( $auction_id );
+							?>
+							<tr class="odd:bg-base-2 even:bg-contrast-5 woocommerce-orders-table__row woocommerce-orders-table__row--status-<?php echo esc_attr( $order->get_status() ); ?> order">
+								<td class="text-xs woocommerce-orders-table__cell woocommerce-orders-table__cell-donation" data-title="donation">
+									<?php foreach ( $order->get_items() as $item ) : ?>
+										<?php
+										$product_id = goodbids()->products->get_parent_product_id( $item['product_id'] );
+										$product    = wc_get_product( $product_id );
+
+										if ( $product ) :
+											?>
+											<a href="<?php echo esc_url( $auction->get_url() ); ?>">
+												<?php echo esc_html( $product->get_title() ); ?>
+											</a>
+										<?php endif; ?>
+									<?php endforeach; ?>
+								</td>
+
+								<td class="text-xs woocommerce-orders-table__cell woocommerce-orders-table__cell-nonprofit" data-title="nonprofit">
+									<a href="<?php echo esc_url( get_blog_details( $bid_order['site_id'] )->siteurl ); ?>">
+										<?php echo esc_html( get_blog_details( $bid_order['site_id'] )->blogname ); ?>
+									</a>
+								</td>
+
+								<td class="text-xs woocommerce-orders-table__cell woocommerce-orders-table__cell-date" data-title="date">
+									<?php
+									if ( $order->get_total() <= 0 ) {
+										printf(
+											'<span style="text-decoration:line-through;opacity:0.5;">%s</span>&nbsp;',
+											wp_kses_post( $order->get_subtotal_to_display() )
+										);
+									}
+									echo wp_kses_post( $order->get_formatted_order_total() );
+									?>
+								</td>
+
+								<td class="text-xs woocommerce-orders-table__cell woocommerce-orders-table__cell-total" data-title="total">
+									<time datetime="<?php echo esc_attr( $order->get_date_created()->date( 'c' ) ); ?>">
+										<?php echo esc_html( $order->get_date_created()->date( 'm/d/y' ) ); ?>
+									</time>
+								</td>
+
+								<td class="text-xs woocommerce-orders-table__cell woocommerce-orders-table__cell-actions" data-title="actions">
+									<?php
+									$actions = wc_get_account_orders_actions( $order );
+									if ( ! empty( $actions ) ) :
+										foreach ( $actions as $key => $wc_action ) :
+											printf(
+												'<a href="%s" class="!mb-0 capitalize btn-fill-sm %s">%s</a>',
+												esc_url( $wc_action['url'] ),
+												sanitize_html_class( $key ),
+												esc_html( $wc_action['name'] )
+											);
+										endforeach;
+									endif;
+									?>
+								</td>
+							</tr>
+							<?php
+						},
+						$bid_order['site_id']
+					);
+				endforeach;
+				?>
+			</tbody>
+		</table>
+	</div>
+
+	<?php do_action( 'woocommerce_before_account_orders_pagination' ); ?>
+
+	<?php if ( 1 < $max_pages ) : ?>
+		<div class="woocommerce-pagination woocommerce-pagination--with-numbers woocommerce-Pagination">
+			<?php
+			echo wp_kses_post(
+				paginate_links(
+					[
+						'base'      => esc_url_raw( wc_get_endpoint_url( Account::BIDS_SLUG, '%_%' ) ),
+						'format'    => '%#%',
+						'add_args'  => false,
+						'current'   => max( 1, $current_page ),
+						'total'     => $max_pages,
+						'prev_text' => '&larr;',
+						'next_text' => '&rarr;',
+						'type'      => 'list',
+						'end_size'  => 3,
+						'mid_size'  => 3,
+					]
+				)
+			);
+			?>
+		</div>
+	<?php endif; ?>
+
+<?php else : ?>
+
+	<?php wc_print_notice( esc_html__( 'You have not bid on any auctions yet.', 'goodbids' ), 'notice' ); // phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment ?>
+
+<?php endif; ?>
+
+<?php do_action( 'woocommerce_after_account_orders', $has_orders ); ?>

--- a/client-mu-plugins/goodbids/views/woocommerce/myaccount/my-rewards.php
+++ b/client-mu-plugins/goodbids/views/woocommerce/myaccount/my-rewards.php
@@ -1,32 +1,25 @@
 <?php
 /**
- * Rewards (copy of Orders) page.
+ * Rewards (copy of Bids, originally Orders) page.
  *
  * Shows Reward orders on the account page.
  *
- * @global array  $reward_orders
- * @global bool   $has_orders
- * @global string $wp_button_class
- * @global int    $current_page
+ * @var array $reward_orders
+ * @var bool  $has_orders
+ * @var int   $current_page
+ * @var int   $total_orders
+ * @var int   $max_pages
  *
  * @see https://woo.com/document/template-structure/
  * @package WooCommerce\Templates
  * @version 8.5.0
  */
 
+use GoodBids\Plugins\WooCommerce\Account;
+
 defined( 'ABSPATH' ) || exit;
 
-// Customizations
-$disabled_columns = [ 'order-total' ];
-
-// Handle pagination.
-$max_per_page  = goodbids()->get_config( 'woocommerce.account.default-orders-per-page' );
-$max_pages     = ceil( $has_orders / $max_per_page );
-$offset        = ( $current_page - 1 ) * $max_per_page;
-$reward_orders = array_slice( $reward_orders, $offset, $max_per_page );
-
 do_action( 'woocommerce_before_account_orders', $has_orders ); ?>
-
 
 <h1><?php esc_html_e( 'Rewards', 'goodbids' ); ?></h1>
 
@@ -46,9 +39,9 @@ do_action( 'woocommerce_before_account_orders', $has_orders ); ?>
 
 			<tbody>
 				<?php
-				foreach ( $reward_orders as $reward_order ) {
+				foreach ( $reward_orders as $reward_order ) :
 					goodbids()->sites->swap(
-						function () use ( $reward_order, $disabled_columns ) {
+						function () use ( $reward_order ) {
 							$order = wc_get_order( $reward_order['order_id'] ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 							?>
 							<tr class="odd:bg-base-2 even:bg-contrast-5 woocommerce-orders-table__row woocommerce-orders-table__row--status-<?php echo esc_attr( $order->get_status() ); ?> order">
@@ -84,18 +77,18 @@ do_action( 'woocommerce_before_account_orders', $has_orders ); ?>
 
 								<td class="text-xs woocommerce-orders-table__cell woocommerce-orders-table__cell-action" data-title="<?php esc_attr_e( 'Action', 'goodbids' ); ?>">
 									<?php
-											$actions = wc_get_account_orders_actions( $order );
+									$actions = wc_get_account_orders_actions( $order );
 
-									if ( ! empty( $actions ) ) {
-										foreach ( $actions as $key => $action ) { // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+									if ( ! empty( $actions ) ) :
+										foreach ( $actions as $key => $action ) : // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 											printf(
 												'<a href="%s" class="btn-fill-sm %s">%s</a>',
 												esc_url( $action['url'] ),
 												sanitize_html_class( $key ),
 												esc_html( $action['name'] )
 											);
-										}
-									}
+										endforeach;
+									endif;
 									?>
 								</td>
 							</tr>
@@ -103,7 +96,7 @@ do_action( 'woocommerce_before_account_orders', $has_orders ); ?>
 						},
 						$reward_order['site_id']
 					);
-				}
+				endforeach;
 				?>
 			</tbody>
 		</table>
@@ -117,7 +110,7 @@ do_action( 'woocommerce_before_account_orders', $has_orders ); ?>
 			echo wp_kses_post(
 				paginate_links(
 					[
-						'base'      => esc_url_raw( wc_get_endpoint_url( 'rewards', '%_%' ) ),
+						'base'      => esc_url_raw( wc_get_endpoint_url( Account::REWARDS_SLUG, '%_%' ) ),
 						'format'    => '%#%',
 						'add_args'  => false,
 						'current'   => max( 1, $current_page ),


### PR DESCRIPTION
# Summary

This PR removes the Orders tab and replaces it with a Bids tab. It also fixes pagination on the Rewards tab.

**Note:** This PR requires an update to Permalinks!

## Issues

* #731 

## Testing Instructions

1. Visit My Account > Bids
2. Try to navigate through pages
3. Same for My Account > Rewards if you have that many rewards (Claire/Steven...)

## Screenshots

<img width="1162" alt="Screenshot 2024-03-15 at 5 56 45 AM" src="https://github.com/Good-Bids/goodbids/assets/122309362/2efed327-12fe-4385-9a34-1d2a3567de4a">

