### PR TITLE
[#746] Updating the padding around the homepage blocks

### DIFF
--- a/client-mu-plugins/goodbids/src/assets/css/global-forms.css
+++ b/client-mu-plugins/goodbids/src/assets/css/global-forms.css
@@ -17,13 +17,13 @@
 			@apply rounded border-solid border-base bg-contrast text-base-2 placeholder:text-base focus:outline-contrast-3;
 		}
 
-		.contact-form__select-wrapper:after {
-			@apply !bottom-0 !top-0 !m-auto;
-		}
-
 		.wp-block-button__link {
 			@apply btn-fill-secondary;
 		}
+	}
+
+	.contact-form .contact-form__select-wrapper:after {
+		@apply !bottom-0 !top-0 !m-auto;
 	}
 
 	/* WooCommerce Forms */

--- a/client-mu-plugins/goodbids/src/assets/css/main.css
+++ b/client-mu-plugins/goodbids/src/assets/css/main.css
@@ -6,6 +6,7 @@
 @import 'activate-page.css';
 
 /* Patterns */
+@import 'patterns/blocks.css';
 @import 'patterns/comments.css';
 @import 'patterns/nonprofit-interest-form.css';
 @import 'patterns/header.css';

--- a/client-mu-plugins/goodbids/src/assets/css/patterns/blocks.css
+++ b/client-mu-plugins/goodbids/src/assets/css/patterns/blocks.css
@@ -1,0 +1,8 @@
+@layer components {
+	.wp-block-media-text.has-media-on-the-right .wp-block-media-text__content {
+		@apply sm:!pl-1;
+	}
+	.wp-block-media-text .wp-block-media-text__content {
+		@apply sm:!pr-1;
+	}
+}

--- a/themes/goodbids-nonprofit/patterns/template-home-nonprofit.php
+++ b/themes/goodbids-nonprofit/patterns/template-home-nonprofit.php
@@ -7,7 +7,7 @@
  */
 
 ?>
-<!-- wp:group {"align":"full","layout":{"type":"constrained"}} -->
+<!-- wp:group {"align":"full","layout":{"type":"constrained"},"metadata":{"name":"Nonprofit Homepage"}} -->
 <div class="wp-block-group alignfull">
 	<!-- wp:media-text {"align":"wide","mediaPosition":"right","verticalAlignment":"top"} -->
 	<div class="wp-block-media-text alignwide has-media-on-the-right is-stacked-on-mobile is-vertically-aligned-top">
@@ -33,16 +33,16 @@
 	</div>
 	<!-- /wp:media-text -->
 
-	<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"0","bottom":"0","left":"var:preset|spacing|40","right":"var:preset|spacing|40"}},"border":{"radius":"0px"}},"layout":{"type":"constrained"}} -->
-	<div class="wp-block-group alignwide" style="border-radius:0px;padding-top:0;padding-right:var(--wp--preset--spacing--40);padding-bottom:0;padding-left:var(--wp--preset--spacing--40)">
-		<!-- wp:video {"id":103,"align":"wide"} -->
-		<figure class="wp-block-video alignwide"></figure>
+	<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"0","bottom":"0","left":"0","right":"0"}},"border":{"radius":"0px"}},"layout":{"type":"constrained"}} -->
+	<div class="wp-block-group alignwide" style="border-radius:0px;padding-top:0;padding-right:0;padding-bottom:0;padding-left:0">
+		<!-- wp:video {"id":103,"responsive":true,"align":"full","className":"alignfull"} -->
+		<figure class="wp-block-video alignfull"></figure>
 		<!-- /wp:video -->
 	</div>
 	<!-- /wp:group -->
 
-	<!-- wp:group {"align":"wide","style":{"spacing":{"margin":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50"},"padding":{"right":"var:preset|spacing|40","left":"var:preset|spacing|40"}}},"layout":{"type":"constrained"}} -->
-	<div class="wp-block-group alignwide" style="margin-top:var(--wp--preset--spacing--50);margin-bottom:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--40)">
+	<!-- wp:group {"align":"wide","style":{"spacing":{"margin":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50"},"padding":{"right":"0","left":"0"}}},"layout":{"type":"constrained"}} -->
+	<div class="wp-block-group alignwide" style="margin-top:var(--wp--preset--spacing--50);margin-bottom:var(--wp--preset--spacing--50);padding-right:0;padding-left:0">
 		<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"0","bottom":"0","left":"0","right":"0"}}},"layout":{"type":"constrained","justifyContent":"center"}} -->
 		<div class="wp-block-group alignwide" style="padding-top:0;padding-right:0;padding-bottom:0;padding-left:0">
 			<!-- wp:heading {"align":"wide","fontSize":"xx-large"} -->


### PR DESCRIPTION
# Summary

This updates the padding around the homepage blocks. The padding on the media-text block is only adjusted on the frontend. One thing to note is the video block is set to `full` width, but when you add a video to it, Gutenberg adjusted it back to the `wide` width. We could look into this, but would require reverse engineering the block, which feels like technical debt for just some padding. 

Also fixed the form select arrow, again. 

## Issues

* #746

## Testing Instructions

1. Create a new site. Or reset the homepage. 
2. Make sure the blocks align with the header. 

## Screenshots
<img width="1343" alt="Screenshot 2024-03-15 at 9 38 37 AM" src="https://github.com/Good-Bids/goodbids/assets/91974372/d7ca3e96-e316-4d41-9091-87c5568b300e">
<img width="380" alt="Screenshot 2024-03-15 at 9 39 39 AM" src="https://github.com/Good-Bids/goodbids/assets/91974372/ad04239c-1695-4e70-9e8d-4ee60f185bc7">
