### PR TITLE
[#766] Fixing All auctions ordering

### DIFF
--- a/client-mu-plugins/goodbids/blocks/all-auctions/block.php
+++ b/client-mu-plugins/goodbids/blocks/all-auctions/block.php
@@ -247,7 +247,6 @@ class AllAuctions extends ACFBlock {
 			'starting' => 'calculate_starting_bid',
 			'ending'   => 'get_end_date_time',
 			'low_bid'  => 'bid_variation_price',
-			'popular'  => 'get_watch_count',
 			default    => false,
 		};
 


### PR DESCRIPTION
# Summary

This fixes two bugs with the all auction sorting. The first is the popular sort which is the default so we don't need a filter for that and the current one was sorting by watched auctions. 
The second one is the sorting by start date. We just need to reverse the array as it was soring by oldest to newest. 

## Issues

* #766 

## Testing Instructions

1. Go to a page that has the all auction block and make sure the filtering is correct.
2. Most Popular - filter by most bids and the total raised
3. Newest - sort by newest to oldest auction

## Screenshots

NA
