### PR TITLE
[#772] Updating when we trim the excerpt

### DIFF
--- a/client-mu-plugins/goodbids/src/classes/Auctions/Auctions.php
+++ b/client-mu-plugins/goodbids/src/classes/Auctions/Auctions.php
@@ -795,14 +795,18 @@ class Auctions {
 	 */
 	private function remove_excerpt_placeholder(): void {
 		add_action(
+			'init',
+			function () {
+				remove_filter( 'get_the_excerpt', 'wp_trim_excerpt' );
+			}
+		);
+		add_action(
 			'current_screen',
 			function (): void {
 				$screen = get_current_screen();
 				if ( $this->get_post_type() !== $screen->post_type ) {
 					return;
 				}
-
-				remove_filter( 'get_the_excerpt', 'wp_trim_excerpt' );
 				?>
 				<style>
 					a.block-editor-rich-text__editable.wp-block-post-excerpt__more-link.rich-text {


### PR DESCRIPTION
# Summary

Look into this a bit more and WP add the default text before the page loads and then again just before it saves the page. As well as when it loads the page. So set it to fire on `init` which covers everything and that fixed the bug. 

## Issues

* #772

## Testing Instructions

1. Create a new auction and leave the excerpt blank.
2. Make sure it is empty on the frontend of the site. 

## Screenshots

NA
