### PR TITLE
[n/a] Remove bid-specific text from View Order page

### DIFF
--- a/client-mu-plugins/goodbids/views/woocommerce/myaccount/view-order.php
+++ b/client-mu-plugins/goodbids/views/woocommerce/myaccount/view-order.php
@@ -105,4 +105,4 @@ $request_args = [
 ?>
 <h3><?php esc_html_e( 'Need Help?', 'goodbids' ); ?></h3>
 
-<p><a href="<?php echo esc_url( goodbids()->support->get_form_url( $request_args ) ); ?>"><?php esc_html_e( 'Submit a support request', 'goodbids' ); ?></a> <?php esc_html_e( 'to', 'goodbids' ); ?> <?php echo esc_html( $nonprofit->get_name() ); ?> <?php esc_html_e( '.', 'goodbids' ); ?></p>
+<p><a href="<?php echo esc_url( goodbids()->support->get_form_url( $request_args ) ); ?>"><?php esc_html_e( 'Submit a support request', 'goodbids' ); ?></a> <?php esc_html_e( 'to', 'goodbids' ); ?> <?php echo esc_html( $nonprofit->get_name() ); ?>.</p>


### PR DESCRIPTION
Currently, the "Need Help" section on both the Bid and Reward View oder page says "for this bid." 

I can see how we'd be able to customize the text for a Bid vs. a Reward order, but the happiest path was just to remove this text entirely to make it generic for both order types. 