### PR TITLE
[N/A] Email did_init (Test)

### DIFF
--- a/client-mu-plugins/goodbids/src/classes/Plugins/WooCommerce/Emails/Email.php
+++ b/client-mu-plugins/goodbids/src/classes/Plugins/WooCommerce/Emails/Email.php
@@ -83,6 +83,15 @@ class Email extends WC_Email {
 	public $recipient = '';
 
 	/**
+	 * Check if this has been initialized yet.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @var bool
+	 */
+	protected $did_init = false;
+
+	/**
 	 * Set default vars and placeholders
 	 *
 	 * @since 1.0.0

--- a/client-mu-plugins/goodbids/src/classes/Plugins/WooCommerce/Emails/SupportRequest.php
+++ b/client-mu-plugins/goodbids/src/classes/Plugins/WooCommerce/Emails/SupportRequest.php
@@ -26,6 +26,10 @@ class SupportRequest extends Email {
 	 * @since 1.0.0
 	 */
 	public function __construct() {
+		if ( $this->did_init ) {
+			return;
+		}
+
 		parent::__construct();
 
 		$this->id                 = 'goodbids_support_request';
@@ -37,6 +41,8 @@ class SupportRequest extends Email {
 		$this->super_admins_email = true;
 
 		$this->trigger_on_new_support_request();
+
+		$this->did_init = true;
 	}
 
 	/**


### PR DESCRIPTION
# Summary

This PR adds a `did_init` flag to emails to prevent them from initializing multiple times. The hope is that this fixes the duplicate email issue, but doesn't break the header/footer in the email template again.

## Issues

* N/A

## Testing Instructions

1. Visit `/support-request/` on a Nonprofit site.
2. Submit the form
3. Verify if this fixes it.
