### PR TITLE
[Draft Ticket] Fix Issue where Reward Orders affects Free Bids

### DIFF
--- a/client-mu-plugins/goodbids/src/classes/Auctions/Bids.php
+++ b/client-mu-plugins/goodbids/src/classes/Auctions/Bids.php
@@ -686,12 +686,12 @@ class Bids {
 		add_action(
 			'goodbids_order_payment_complete',
 			function ( int $order_id, int $auction_id ) {
-				$auction = goodbids()->auctions->get( $auction_id );
-
 				// Only process Bid Orders.
 				if ( Bids::ITEM_TYPE !== goodbids()->woocommerce->orders->get_type( $order_id ) ) {
 					return;
 				}
+
+				$auction = goodbids()->auctions->get( $auction_id );
 
 				// Do not award free bids if this order contains a free bid.
 				if ( goodbids()->woocommerce->orders->is_free_bid_order( $order_id ) ) {


### PR DESCRIPTION
# Summary

This PR prevents Reward Orders from having any effect on Free Bids (Auction or User).

## Issues

* [[Draft](https://github.com/orgs/Good-Bids/projects/4/views/4?pane=issue&itemId=56874833)]

## Testing Instructions

1. Claim a Reward
2. Do not get more free bids.
