### PR TITLE
[#802] Remove refund request option

### DIFF
--- a/client-mu-plugins/goodbids/src/classes/Frontend/SupportRequest.php
+++ b/client-mu-plugins/goodbids/src/classes/Frontend/SupportRequest.php
@@ -992,13 +992,6 @@ class SupportRequest {
 								'value' => __( 'Issue', 'goodbids' ),
 							],
 							[
-								'label' => __( 'Request a refund', 'goodbids' ),
-								'value' => __( 'Refund', 'goodbids' ),
-								'dependencies' => [
-									Request::FIELD_TYPE => Request::TYPE_BID,
-								],
-							],
-							[
 								'label' => __( 'Ask a question', 'goodbids' ),
 								'value' => __( 'Question', 'goodbids' ),
 							],


### PR DESCRIPTION
We no longer need to include "Request a refund" as an option for "What is the nature of your request?" for Bid orders on the Support Request form. :) 