### PR TITLE
[n/a] Turning back on woocommerce marketing menu

### DIFF
--- a/client-mu-plugins/goodbids/src/classes/Plugins/WooCommerce/Admin.php
+++ b/client-mu-plugins/goodbids/src/classes/Plugins/WooCommerce/Admin.php
@@ -233,31 +233,6 @@ class Admin {
 			200
 		);
 
-		// Remove WooCommerce Marketing Menu.
-		add_filter(
-			'woocommerce_admin_features',
-			function ( array $features ): array {
-				if ( ! is_main_site() ) {
-					return $features;
-				}
-
-				$keep = [
-					'homescreen',
-					'navigation',
-					'activity-panels',
-					'store-alerts',
-					'remote-inbox-notifications',
-					'woo-mobile-welcome',
-					'store-alert',
-				];
-
-				return array_filter(
-					$features,
-					fn( $feature ) => in_array( $feature, $keep, true )
-				);
-			}
-		);
-
 		// Remove WooCommerce Analytics Menu.
 		add_filter(
 			'option_woocommerce_analytics_enabled',


### PR DESCRIPTION
# Summary

This removes the hiding of the WC marketing menu filter because it was removing the JS/CSS on the Stripe page. 

## Issues

* NA

## Testing Instructions

1. Go to the main site -> WC -> Stripe.
2. Make sure the styling is showing and you can open the models. 

## Screenshots
 
<img width="1104" alt="Screenshot 2024-03-19 at 11 57 28 AM" src="https://github.com/Good-Bids/goodbids/assets/91974372/14fad12b-ee48-476f-a021-45a2cf2641e8">
