### PR TITLE
[N/A] Admin > Users Bug Fix

### DIFF
--- a/client-mu-plugins/goodbids/src/classes/Users/Referrals/Admin.php
+++ b/client-mu-plugins/goodbids/src/classes/Users/Referrals/Admin.php
@@ -371,6 +371,10 @@ class Admin {
 		add_filter(
 			'manage_users_custom_column',
 			function ( string $value, string $column, int $user_id ) {
+				if ( ! $user_id ) {
+					return '&mdash;';
+				}
+
 				$referrer = new Referrer( $user_id );
 
 				if ( 'referral_count' === $column ) {


### PR DESCRIPTION
# Summary

This PR fixes an issue when a user has been deleted when trying to view WP Admin > Users

## Issues

* N/A

## Testing Instructions

1. Delete a User
2. Visit WP Admin > User
3. Make sure the table displays.
