### PR TITLE
[#820] Disable Shop Manager Role

### DIFF
--- a/client-mu-plugins/goodbids/src/classes/Users/Permissions.php
+++ b/client-mu-plugins/goodbids/src/classes/Users/Permissions.php
@@ -436,9 +436,9 @@ class Permissions {
 				// This permanently removes the roles.
 				remove_role( 'subscriber' );
 				remove_role( 'contributor' );
-				remove_role( 'shop_manager' );
 				remove_role( 'author' );
 				remove_role( 'editor' );
+				remove_role( 'shop_manager' );
 				remove_role( 'vip_support' );
 				remove_role( 'vip_support_inactive' );
 			}
@@ -457,7 +457,11 @@ class Permissions {
 		add_filter(
 			'editable_roles',
 			function ( array $roles ): array {
-				// Disable the Shop Manager Role
+				// Disable the Unused Roles
+				unset( $roles['subscriber'] );
+				unset( $roles['contributor'] );
+				unset( $roles['author'] );
+				unset( $roles['editor'] );
 				unset( $roles['shop_manager'] );
 
 				if ( goodbids()->utilities->network_is_main_site() ) {


### PR DESCRIPTION
# Summary

This PR disables the Shop Manager Role when adding new users or changing User roles.

## Issues

* #820 

## Testing Instructions

1. Visit WP Admin > Users on a Nonprofit site
2. Make sure "Shop Manager" does not show up in role selection list.

## Screenshots

<img width="413" alt="Screenshot 2024-03-21 at 10 58 42 AM" src="https://github.com/Good-Bids/goodbids/assets/122309362/deec1de7-fdb5-460c-a1e4-16990ca9d5a4">
