### PR TITLE
[n/a] - fix: add miniorange specificity

### DIFF
--- a/client-mu-plugins/goodbids/config.json
+++ b/client-mu-plugins/goodbids/config.json
@@ -7,7 +7,7 @@
   "active-plugins": [
     "advanced-custom-fields-pro/acf.php",
     "delete-me",
-    "miniorange-oauth-20-server",
+    "miniorange-oauth-20-server/mo_oauth_settings.php",
     "miniorange-oauth-oidc-single-sign-on/mo_oauth_settings.php",
     "modal-block",
     "tidio-live-chat/tidio-elements.php",


### PR DESCRIPTION
# Summary
the config.json file wasn't correctly loading miniorange's OAuth plugin (possibly due to the file name being different in the directory?). Adding some specificity to point to the exact plugin file in the directory.