### PR TITLE
test: added specific callout to vendors directory in composer config

### DIFF
--- a/client-mu-plugins/goodbids/composer.json
+++ b/client-mu-plugins/goodbids/composer.json
@@ -18,7 +18,8 @@
 			"dealerdirect/phpcodesniffer-composer-installer": true,
 			"cweagans/composer-patches": true,
 			"oomphinc/composer-installers-extender": true
-		}
+		},
+		"vendor-dir": "vendor"
 	},
 	"autoload": {
 		"psr-4": {


### PR DESCRIPTION
# Summary

- Following along [here](https://docs.wpvip.com/github-repository/composer/#h-referencing-the-root-vendor-directory), in an attempt to solve [this support ticket](https://support.wpvip.com/hc/en-us/requests/183579) (miniorange oauth failing due to plugin tables not existing).

- Need to deploy to dev to test efficacy.