### PR TITLE
test: try manual activation to trigger hooks

### DIFF
--- a/client-mu-plugins/goodbids/config.json
+++ b/client-mu-plugins/goodbids/config.json
@@ -7,7 +7,6 @@
   "active-plugins": [
     "advanced-custom-fields-pro/acf.php",
     "delete-me",
-    "miniorange-oauth-20-server/mo_oauth_settings.php",
     "miniorange-oauth-oidc-single-sign-on/mo_oauth_settings.php",
     "popup-maker",
     "tidio-live-chat/tidio-elements.php",


### PR DESCRIPTION
# Summary

Trying a manual activation pattern to trigger the necessary db writes for mini orange's oauth server plugin