### PR TITLE
chore: Move dialog trigger to bid button

### DIFF
--- a/client-mu-plugins/goodbids/src/blocks/bidding/components/Driver.tsx
+++ b/client-mu-plugins/goodbids/src/blocks/bidding/components/Driver.tsx
@@ -11,7 +11,6 @@ import { ParticipationNotice } from './participation-notice';
 import { Fetcher } from './fetcher';
 import { Socket } from './socket';
 import { SocketError } from './socket-error';
-import { FirstTimeDialog } from './first-time-dialog';
 
 type DriverProps = {
 	auctionId: number;
@@ -37,7 +36,6 @@ export function Driver({ auctionId }: DriverProps) {
 						<ParticipationNotice />
 						<FreeBidsPromo />
 						<SocketError />
-						<FirstTimeDialog />
 					</LayoutGroup>
 				</motion.div>
 			</Fetcher>

--- a/client-mu-plugins/goodbids/src/blocks/bidding/components/bid-button/index.tsx
+++ b/client-mu-plugins/goodbids/src/blocks/bidding/components/bid-button/index.tsx
@@ -8,9 +8,10 @@ import {
 import { useBiddingState } from '../../store';
 import { AuctionStatus } from '../../store/types';
 import clsx from 'clsx';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { fadeAnimation } from '../../utils/animations';
 import { __ } from '@wordpress/i18n';
+import { FirstTimeDialog } from '../first-time-dialog';
 
 const closingStatuses: AuctionStatus[] = ['closing', 'preclosing'];
 const liveAndClosingStatuses: AuctionStatus[] = ['live', ...closingStatuses];
@@ -22,7 +23,6 @@ export function BidButton() {
 		<AnimatePresence>
 			{liveAndClosingStatuses.includes(auctionStatus) && (
 				<>
-					{/* <FirstTimeDialog /> */}
 					<LiveAndClosing />
 				</>
 			)}
@@ -41,6 +41,8 @@ export function BidButton() {
 function LiveAndClosing() {
 	const { isLastBidder, currentBid, bidUrl, auctionStatus } =
 		useBiddingState();
+
+	const [showDialog, setShowDialog] = useState(false);
 
 	const motionValue = useMotionValue(currentBid);
 	const calculatedValue = useTransform(
@@ -65,16 +67,21 @@ function LiveAndClosing() {
 	}, [currentBid, motionValue]);
 
 	return (
-		<motion.a
-			layout
-			{...fadeAnimation}
-			className={classes}
-			href={isLastBidder ? '#' : bidUrl}
-			aria-live="polite"
-		>
-			{__('GOODBID', 'goodbids')}{' '}
-			<motion.span>{calculatedValue}</motion.span> {__('Now', 'goodbids')}
-		</motion.a>
+		<>
+			<motion.a
+				layout
+				{...fadeAnimation}
+				className={classes}
+				href={isLastBidder ? '#' : bidUrl}
+				aria-live="polite"
+				onClick={() => setShowDialog(true)}
+			>
+				{__('GOODBID', 'goodbids')}{' '}
+				<motion.span>{calculatedValue}</motion.span>{' '}
+				{__('Now', 'goodbids')}
+			</motion.a>
+			<FirstTimeDialog showDialog={showDialog} />
+		</>
 	);
 }
 

--- a/client-mu-plugins/goodbids/src/blocks/bidding/components/first-time-dialog/index.tsx
+++ b/client-mu-plugins/goodbids/src/blocks/bidding/components/first-time-dialog/index.tsx
@@ -2,7 +2,8 @@ import clsx from 'clsx';
 import { FormEvent, useEffect, useState } from 'react';
 import { WarningIconFilled } from '../icons/warning-icon-filled';
 
-export const FirstTimeDialog = () => {
+export const FirstTimeDialog = (props: { showDialog: boolean }) => {
+	const { showDialog } = props;
 	const [hasSeenDialog, setHasSeenDialog] = useState(true);
 
 	const cookieString = 'gb-has-seen-first-time-dialog';
@@ -28,6 +29,7 @@ export const FirstTimeDialog = () => {
 	);
 
 	return (
+		showDialog &&
 		!hasSeenDialog && (
 			<div className="fixed inset-0 left-0 top-0 z-50 flex items-center justify-center overflow-y-auto overflow-x-hidden outline-none focus:outline-none">
 				<dialog className={dialogClasses} open={!hasSeenDialog}>


### PR DESCRIPTION
# Summary

Rather than show the first time dialog when a user lands on an auction page, we want it to show up when they click "bid now"

## Testing Instructions

1. clear your localstorage of the gb-has-seen-first-time-dialog cookie
2. navigate to a live local auction
3. click 'bid now' - a dialog should appear
4. enter `soafind` and click `I understand`- you should be prompted to enter a value that matches the pattern
5. enter `donation` and click `I understand`- the dialog should close, and you should get pushed to the checkout flow

## Screenshots

![2024-04-04 04 53 48](https://github.com/Good-Bids/goodbids/assets/128058464/eb8130bd-f74d-419c-b29d-65e7bf174885)

