### PR TITLE
[#876] Force Admin Table Position

### DIFF
--- a/client-mu-plugins/goodbids/src/assets/css/admin.css
+++ b/client-mu-plugins/goodbids/src/assets/css/admin.css
@@ -131,3 +131,7 @@ tr.separator td {
 	padding: 0;
 	pointer-events: none;
 }
+
+table.fixed {
+	position: static !important;
+}


### PR DESCRIPTION
# Summary

This PR is a stop-gap fix to resolve the issue caused by the `fixed` class that is added into the `admin.css` file via Tailwind.

## Issues

* #876 

## Testing Instructions

1. Visit any admin page with a WP List Table (Pages, Sites, etc)
2. Make sure the table is rendered with a position of `static` and not `fixed`.
