### PR TITLE
[#877] Customize Stripe Payment Description for Auctions

### DIFF
--- a/client-mu-plugins/goodbids/src/classes/Plugins/WooCommerce/Stripe.php
+++ b/client-mu-plugins/goodbids/src/classes/Plugins/WooCommerce/Stripe.php
@@ -8,6 +8,8 @@
 
 namespace GoodBids\Plugins\WooCommerce;
 
+use WC_Order;
+
 /**
  * Stripe Tweaks
  *
@@ -23,6 +25,9 @@ class Stripe {
 	public function __construct() {
 		// Change nulls to empty strings.
 		$this->clear_stripe_nulls();
+
+		// Customize the Transaction Description
+		$this->custom_transaction_description();
 	}
 
 	/**
@@ -53,5 +58,35 @@ class Stripe {
 
 		add_filter( 'option_woocommerce_stripe_settings', $clear_nulls, 50 );
 		add_filter( 'default_option_woocommerce_stripe_settings', $clear_nulls, 50 );
+	}
+
+	/**
+	 * Adjust the Transaction Description for Stripe Payments
+	 *
+	 * @since 1.0.1
+	 *
+	 * @return void
+	 */
+	private function custom_transaction_description(): void {
+		if ( is_main_site() ) {
+			return;
+		}
+
+		add_filter(
+			'wc_stripe_payment_metadata',
+			function( array $metadata, WC_Order $order ): array {
+				// Original: %1$s - Order %2$s
+				$metadata['description'] = sprintf(
+					// translators: %1$s is the Nonprofit name, %2$s is the order number
+					__( 'GOODBIDS: %1$s - Order %2$s', 'goodbids' ),
+					wp_specialchars_decode( get_bloginfo( 'name' ), ENT_QUOTES ),
+					$order->get_order_number()
+				);
+
+				return $metadata;
+			},
+			10,
+			2
+		);
 	}
 }


### PR DESCRIPTION
# Summary

This PR Adds "GOODBIDS" to the Stripe Transaction Description just before the Nonprofit name.

## Issues

* #877 

## Testing Instructions

1. Place a bid
2. Review the Stripe Account Payment Details
