### PR TITLE
[#884] Transform Special chars in Auction Title included in Email Body

### DIFF
--- a/client-mu-plugins/goodbids/src/classes/Plugins/WooCommerce/Emails/Email.php
+++ b/client-mu-plugins/goodbids/src/classes/Plugins/WooCommerce/Emails/Email.php
@@ -317,7 +317,7 @@ class Email extends WC_Email {
 		// Woohoo, send the email!
 		$this->send(
 			$this->get_recipient(),
-			goodbids()->utilities->sanitize_email_subject( $this->get_subject() ),
+			goodbids()->utilities->sanitize_email_special_chars( $this->get_subject() ),
 			$this->get_content(),
 			$this->get_headers(),
 			$this->get_attachments()
@@ -442,7 +442,7 @@ class Email extends WC_Email {
 		$auction_title = $auction?->get_title() ?: '';
 		$this->add_placeholder( '{auction.url}', $auction?->get_url() );
 		$this->add_placeholder( '{auction.admin_url}', get_edit_post_link( $auction?->get_id() ) );
-		$this->add_placeholder( '{auction.title}', htmlspecialchars( $auction_title ) );
+		$this->add_placeholder( '{auction.title}', goodbids()->utilities->sanitize_email_special_chars( $auction_title ) );
 		$this->add_placeholder( '{auction.start_date_time}', $auction?->get_start_date_time( $datetime_format ) );
 		$this->add_placeholder( '{auction.end_date_time}', $auction?->get_end_date_time( $datetime_format ) );
 

--- a/client-mu-plugins/goodbids/src/classes/Utilities/Utilities.php
+++ b/client-mu-plugins/goodbids/src/classes/Utilities/Utilities.php
@@ -244,16 +244,16 @@ class Utilities {
 	}
 
 	/**
-	 * Sanitize Special Characters from Email Subject
+	 * Sanitize Special Characters in Emails
 	 *
 	 * @since 1.0.1
 	 *
-	 * @param string $subject
+	 * @param string $string
 	 *
 	 * @return string
 	 */
-	public function sanitize_email_subject( string $subject ): string {
-		$subject = htmlspecialchars_decode( $subject );
-		return html_entity_decode( $subject );
+	public function sanitize_email_special_chars( string $string ): string {
+		$string = htmlspecialchars_decode( $string );
+		return html_entity_decode( $string );
 	}
 }


### PR DESCRIPTION
# Summary

This PR applies special character transformation to the Auction Title that appears in the body.

## Issues

* #884 

## Testing Instructions

1. Create an Auction with some crazy characters
2. Bid on that Auction
3. Review the Bid Email (content) to make sure no strange character encodings appear in the email body.

