### PR TITLE
[#882] Default role customer

### DIFF
--- a/client-mu-plugins/goodbids/src/classes/Users/Permissions.php
+++ b/client-mu-plugins/goodbids/src/classes/Users/Permissions.php
@@ -476,7 +476,7 @@ class Permissions {
 	}
 
 	/**
-	 * Set the default role for Nonprofits to Administrator.
+	 * Set the default role for Nonprofits to Customer.
 	 *
 	 * @since 1.0.0
 	 *


### PR DESCRIPTION
# Summary

This PR sets the default role to `customer` when `get_option( 'default_role' )` is called.

## Issues

* #882 

## Testing Instructions

1. Register on the site using OAuth
2. Ensure your role is set to Customer and not Administrator
