### PR TITLE
Revert "[NA] - update auction closed email (#887)"

### DIFF
--- a/client-mu-plugins/goodbids/views/woocommerce/emails/auction-closed.php
+++ b/client-mu-plugins/goodbids/views/woocommerce/emails/auction-closed.php
@@ -39,10 +39,11 @@ do_action( 'woocommerce_email_header', $email_heading );
 <p>
 	<?php
 	printf(
-		'%s <a href="%s">goodbids.org/%s</a>.',
-		esc_html__( 'Thank you for being a supporter. Please check our other auctions at', 'goodbids' ),
-		'{auctions_url}',
-		esc_html( Sites::ALL_AUCTIONS_SLUG )
+		'%s <a href="%s">%s</a> %s!',
+		esc_html__( 'Check your email or', 'goodbids' ),
+		'{auction.url}',
+		esc_html__( 'visit the auction page', 'goodbids' ),
+		esc_html__( 'to see if you won!', 'goodbids' )
 	);
 	?>
 </p>


### PR DESCRIPTION
This reverts commit ab8d5c827f58988fd70c43e507be903c8f9672cd.

# Summary
 - Since 4/9, we haven't seen any "[Congratulations, you won!]" emails on staging. Reverting this auction-closed email commit

## Issues

* List any related issues.