### PR TITLE
[#789] Insert Disclaimer into Express Checkout block

### DIFF
--- a/client-mu-plugins/goodbids/src/classes/Plugins/WooCommerce/Cart.php
+++ b/client-mu-plugins/goodbids/src/classes/Plugins/WooCommerce/Cart.php
@@ -149,6 +149,10 @@ class Cart {
 	 * @return ?string
 	 */
 	public function get_order_type(): ?string {
+		if ( ! WC()->cart ) {
+			return null;
+		}
+
 		$cart = WC()->cart->get_cart_contents();
 
 		foreach ( $cart as $cart_item ) {
@@ -169,6 +173,10 @@ class Cart {
 	 * @return float
 	 */
 	public function get_total(): float {
+		if ( ! WC()->cart ) {
+			return 0;
+		}
+
 		return WC()->cart->get_total( 'edit' );
 	}
 }

--- a/client-mu-plugins/goodbids/src/classes/Plugins/WooCommerce/Checkout.php
+++ b/client-mu-plugins/goodbids/src/classes/Plugins/WooCommerce/Checkout.php
@@ -273,12 +273,10 @@ class Checkout {
 					return $block_content;
 				}
 
-				/**
-				The following line appends the disclaimer to the Express Checkout block content, which puts it below the "Or continue below" message. Ideally, the disclaimer should be above that message. In order to do that, the content from the get_paid_bid_disclaimer() method should be inserted via `preg_replace` or similar before the .wc-block-components-express-payment-continue-rule element.
-				**/
-//				$block_content .= $this->get_paid_bid_disclaimer( $bid_amount );
+				$pattern    = '/(<[^>]*class="[^"]*wc-block-components-express-payment-continue-rule[^"]*"[^>]*>)/';
+				$disclaimer = $this->get_paid_bid_disclaimer( $bid_amount ) . '$1';
 
-				return $block_content;
+				return preg_replace( $pattern, $disclaimer, $block_content );
 			},
 			10,
 			2


### PR DESCRIPTION
# Summary

This PR adds the Checkout Disclaimer to the Express Checkout block.

## Issues

* #789 

## Testing Instructions

1. View the Checkout Page
2. The disclaimer should appear below the Express Checkout block.

## Screenshots

<img width="627" alt="Screenshot 2024-04-12 at 1 15 46 PM" src="https://github.com/Good-Bids/goodbids/assets/122309362/76cf2c64-97f3-4460-8082-7af76e3d0ddf">
