### PR TITLE
[n/a] Fixing the z-index of the dropdown sort button

### DIFF
--- a/client-mu-plugins/goodbids/blocks/all-auctions/render.php
+++ b/client-mu-plugins/goodbids/blocks/all-auctions/render.php
@@ -46,7 +46,7 @@ $active_class = 'btn-fill-secondary outline-dotted outline-1 outline-offset-2 ho
 		</ul>
 
 		<?php if ( $total_count > 1 ) : ?>
-			<div class="flex justify-end">
+			<div class="flex justify-end relative z-50">
 				<select
 					aria-label="<?php esc_attr_e( 'Sort Auctions', 'goodbids' ); ?>"
 					class="p-3 pr-10 bg-[right_0.5rem_center] bg-no-repeat border-transparent rounded appearance-none bg-contrast-3 text-contrast bg-select-arrow bg-[length:20px_20px]"


### PR DESCRIPTION
# Summary

This fixes the `z-index` of the all auctions sort button. Before the loading icon `div` just covered the bottom part of the button which made it so you could not click on the bottom of the button. This sets the select dropdown button `z-index` to `50` so it now sits above the loading icon `div`

## Issues

* NA

## Testing Instructions

1. Go to the all auction page on the main or nonprofit sites. 
2. Make sure you can click on the bottom part of the select button. 

## Screenshots
NA
