### PR TITLE
[N/A] Auction Live Emails

### DIFF
--- a/client-mu-plugins/goodbids/src/classes/Auctions/Auction.php
+++ b/client-mu-plugins/goodbids/src/classes/Auctions/Auction.php
@@ -1272,6 +1272,10 @@ class Auction {
 	 * @return bool
 	 */
 	public function trigger_start(): bool {
+		if ( 'publish' !== get_post_status( $this->get_id() ) ) {
+			return false;
+		}
+
 		if ( ! $this->has_started() || $this->start_triggered() ) {
 			return false;
 		}


### PR DESCRIPTION
# Summary

This PR adds checks to the `trigger_start()` and `has_started()` methods to ensure the Auction has been published before returning an affirmative value.

## Issues

* N/A

## Testing Instructions

1. Set an Auction to go live at a specific time.
2. Leave the post status in Draft mode
3. View the Auction (as Admin) after it should have gone live
4. Make sure the Auction is Live email is not triggered.