### PR TITLE
na - static values for threshold

### DIFF
--- a/client-mu-plugins/goodbids/src/classes/Auctions/Auction.php
+++ b/client-mu-plugins/goodbids/src/classes/Auctions/Auction.php
@@ -560,8 +560,13 @@ class Auction {
 			return false;
 		}
 
-		// If the Auction ends in less than the extension threshold, it is ending soon.
-		return $static_threshold_min < $diff < $static_threshold_max;
+		// if the diff is less than the max for the threshold 
+		// and the diff is more than the min for the threshold
+		// (i.e., if it falls within the threshold),
+		// then it's ending soon.
+		$ending_soon = $static_threshold_max > $diff && $static_threshold_min < $diff;
+
+		return $ending_soon;
 	}
 
 	/**


### PR DESCRIPTION
# Summary

Adjusting the threshold for determining whether an auction is ending soon, and setting a lower limit so that users don't get spammed (12 hour extension windows could send notifications up to 4 times).

@bd-viget / @nathan-schmidt-viget - I'm not sure the logic for comparing makes sense in php-land, please double-check. Thanks!