### PR TITLE
[#919] Change Base Share URL for Referrals

### DIFF
--- a/client-mu-plugins/goodbids/src/classes/Network/Sites.php
+++ b/client-mu-plugins/goodbids/src/classes/Network/Sites.php
@@ -48,6 +48,12 @@ class Sites {
 	const AUCTIONS_OPTION = 'gb_auctions_page';
 
 	/**
+	 * @since 1.0.1
+	 * @var string
+	 */
+	const ALL_AUCTIONS_SLUG = 'explore-auctions';
+
+	/**
 	 * @since 1.0.0
 	 * @var string
 	 */
@@ -539,7 +545,7 @@ class Sites {
 		add_action(
 			'goodbids_initialize_site',
 			function (): void {
-				$auctions_slug = 'explore-auctions';
+				$auctions_slug = self::ALL_AUCTIONS_SLUG;
 				$existing      = get_option( self::AUCTIONS_OPTION );
 
 				// Make sure it doesn't already exist.

--- a/client-mu-plugins/goodbids/src/classes/Users/Referrals.php
+++ b/client-mu-plugins/goodbids/src/classes/Users/Referrals.php
@@ -9,6 +9,7 @@
 namespace GoodBids\Users;
 
 use GoodBids\Core;
+use GoodBids\Network\Sites;
 use GoodBids\Users\Referrals\Admin;
 use GoodBids\Users\Referrals\Generator;
 use GoodBids\Users\Referrals\Referral;
@@ -428,6 +429,33 @@ class Referrals {
 				10
 			),
 			ARRAY_A
+		);
+	}
+
+	/**
+	 * Get the base share URL
+	 *
+	 * @since 1.0.1
+	 *
+	 * @return string
+	 */
+	public function get_base_share_url(): string {
+		return goodbids()->sites->main(
+			function () {
+				$share_page_id = get_option( Sites::AUCTIONS_OPTION );
+
+				if ( $share_page_id ) {
+					return get_permalink( $share_page_id );
+				}
+
+				$share_page = get_page_by_path( Sites::ALL_AUCTIONS_SLUG );
+
+				if ( $share_page ) {
+					return get_permalink( $share_page );
+				}
+
+				return site_url(); // Default to the main site Home page.
+			}
 		);
 	}
 }

--- a/client-mu-plugins/goodbids/src/classes/Users/Referrals/Referrer.php
+++ b/client-mu-plugins/goodbids/src/classes/Users/Referrals/Referrer.php
@@ -130,7 +130,7 @@ class Referrer {
 		}
 
 		$code = strtoupper( $this->get_code() );
-		$base = wp_registration_url();
+		$base = goodbids()->referrals->get_base_share_url();
 
 		return add_query_arg( [ Track::REFERRAL_CODE_QUERY_ARG => $code ], $base );
 	}

--- a/client-mu-plugins/goodbids/src/classes/Users/Referrals/Shortcodes.php
+++ b/client-mu-plugins/goodbids/src/classes/Users/Referrals/Shortcodes.php
@@ -8,8 +8,6 @@
 
 namespace GoodBids\Users\Referrals;
 
-use GoodBids\Users\Referrals;
-
 /**
  * Class for Referral Shortcodes
  *

--- a/client-mu-plugins/goodbids/src/classes/Users/Referrals/Track.php
+++ b/client-mu-plugins/goodbids/src/classes/Users/Referrals/Track.php
@@ -74,8 +74,8 @@ class Track {
 					}
 				}
 
-				// Remove referral code from URL.
-				wp_safe_redirect( remove_query_arg( self::REFERRAL_CODE_QUERY_ARG ) );
+				// Redirect to default base share URL.
+				wp_safe_redirect( goodbids()->referrals->get_base_share_url() );
 				exit;
 			},
 			2


### PR DESCRIPTION
# Summary

This PR adjusts the URL used when sharing referral links as well as updates the redirect destination when a referral code is present in the URL to the same URL (for legacy shared URLs)

## Issues

* #919 

## Testing Instructions

1. Go to My Account > Referrals
2. Make sure the Share URL shows the Explore Auctions URL of the Main Site.
3. Go to ANY other URL with the share code query parameter (`/doesnt-even-have-to-exist/?gbr=doesnt-even-have-to-be-valid`)
4. You should get redirected to the Explore Auctions URL of the Main Site.

## Screenshots

<img width="760" alt="Screenshot 2024-04-19 at 4 41 22 PM" src="https://github.com/Good-Bids/goodbids/assets/122309362/ffc883f5-95f2-4570-b7ce-e1da8b5116c8">