### PR TITLE
NA - Update `auctions ending soon` threshold

### DIFF
--- a/client-mu-plugins/goodbids/src/classes/Auctions/Auction.php
+++ b/client-mu-plugins/goodbids/src/classes/Auctions/Auction.php
@@ -539,19 +539,10 @@ class Auction {
 			return false;
 		}
 
-		// commenting out extension logic for now
 		// TODO add a variable in the UI for 'ending soon notification threshold'
-		// $extension = $this->get_bid_extension();
-
-		$static_threshold_min = 60*60; // 60 minutes
-		$static_threshold_max = 60*120; // 120 minutes
-
-		// if ( ! $extension ) {
-		// 	return false;
-		// }
-
-		// Set threshold to be static
-		// $threshold = intval( round( $extension * .3 ) );
+		
+		$static_threshold_min = HOUR_IN_SECONDS * 1; // 60 minutes
+		$static_threshold_max = HOUR_IN_SECONDS * 2; // 120 minutes
 
 		try {
 			$end  = new DateTimeImmutable( $end_date_time, wp_timezone() );


### PR DESCRIPTION
# Summary

Slight adjustment of the 'auction ending soon' logic:
- increase window from `60-115 minutes` to `60-120 minutes`
- add `<=` to eval logic

before these changes, auctions would be excluded if they met this criteria when the check ran:
- they had exactly 60 minutes left
- they had 115.01 --> 120 minutes left. These would also be missed in the subsequent check since they'd be under 60 minutes the next time it ran