### PR TITLE
add redirect from `production.*`

### DIFF
--- a/vip-config/vip-config.php
+++ b/vip-config/vip-config.php
@@ -102,7 +102,7 @@ if ( isset( $_SERVER['HTTP_HOST'] ) && isset( $_SERVER['REQUEST_URI'] ) ) {
 
 	$redirect_to_domain = 'www.goodbids.org';
 	$redirect_domains   = array(
-		// 'production.goodbids.org', TODO <-- add back in once miniorange key is switched over
+		'production.goodbids.org',
 		'goodbids.org',
 	);
 


### PR DESCRIPTION
# Summary
- we had disabled the redirect from `production.*` while we were switching out the miniorange oauth keys to `www.*`
- some of the early np sites have buttons linking to `production.*` sites
- while working to update those sites, also adding this logic back in as an extra safety net for any undiscovered & borked links