### PR TITLE
[#928] Adjust order results to sort by Subtotal

### DIFF
--- a/client-mu-plugins/goodbids/src/classes/Auctions/Auctions.php
+++ b/client-mu-plugins/goodbids/src/classes/Auctions/Auctions.php
@@ -584,7 +584,6 @@ class Auctions {
 	 * @return int[]
 	 */
 	private function sort_orders_by_subtotal( array $orders ): array {
-		$sorted = [];
 		$totals = [];
 
 		foreach ( $orders as $order_id ) {
@@ -594,11 +593,7 @@ class Auctions {
 
 		arsort( $totals );
 
-		foreach ( $totals as $order_id => $total ) {
-			$sorted[] = $order_id;
-		}
-
-		return $sorted;
+		return array_keys( $totals );
 	}
 
 	/**


### PR DESCRIPTION
# Summary

This PR adjusts the sort order of the Bid Orders by Subtotal to ensure they are ordered from Highest Bid to Lowest Bid.

## Issues

* #928 

## Testing Instructions

1. Review Dashboards and Auctions and ensure the Latest Bid is accurate.
