### PR TITLE
[#931] Use JS to insert Express Checkout Disclaimer.

### DIFF
--- a/client-mu-plugins/goodbids/src/classes/Plugins/WooCommerce/Checkout.php
+++ b/client-mu-plugins/goodbids/src/classes/Plugins/WooCommerce/Checkout.php
@@ -312,7 +312,6 @@ class Checkout {
 				echo <<<SCRIPT
 <script>
 (function() {
-	// Add observer when the DOM is ready
 	document.addEventListener( 'DOMContentLoaded', function() {
 
 		const goodbidsExpressCheckoutDisclaimer = function() {


### PR DESCRIPTION
# Summary

This PR uses JS to insert the Express Checkout Disclaimer into the Express Checkout Block if/when it becomes available.

The reason the code before didn't work is because the Express Checkout block is built dynamically after the page has loaded, so we need to inject the disclaimer once the element becomes available.

## Issues

* #931 

## Testing Instructions

1. Visit the checkout page by placing a bid.
2. Note the presence of the Checkout Disclaimer just below the Express Checkout block, but above the "Or continue below" message.

## Screenshots

<img width="704" alt="Screenshot 2024-04-29 at 10 21 42 AM" src="https://github.com/Good-Bids/goodbids/assets/122309362/f6753bf3-feb6-4193-a2a9-27343771d02d">