### PR TITLE
[#1046] Throw Exceptions during final checkout validations

### DIFF
--- a/client-mu-plugins/goodbids/src/classes/Auctions/Cron.php
+++ b/client-mu-plugins/goodbids/src/classes/Auctions/Cron.php
@@ -305,6 +305,10 @@ class Cron {
 
 				foreach ( $auctions->posts as $auction_id ) {
 					$auction = goodbids()->auctions->get( $auction_id );
+					if ( ! $auction->has_ended() ) {
+						continue;
+					}
+
 					$auction->trigger_close();
 				}
 			}


### PR DESCRIPTION
# Summary

This PR throws Route Exceptions (instead of adding WooCommerce notices) during the final REST API validation hook before processing payment so the processing is halted with the error, instead of continuing to proceed.

## Issues

* #1046 

## Testing Instructions

1. Try to trigger any of the validation errors during the final checkout step:
   * AUCTION_NOT_STARTED
   * AUCTION_HAS_ENDED
   * FREE_BIDS_NOT_ELIGIBLE
   * NO_AVAILABLE_FREE_BIDS
   * BID_ALREADY_PLACED

