### PR TITLE
[N/A] Stop/Log Emails + Local Config Setup & README update

### DIFF
--- a/client-mu-plugins/goodbids/composer.json
+++ b/client-mu-plugins/goodbids/composer.json
@@ -35,7 +35,10 @@
 	"repositories": [
 		{
 			"type": "composer",
-			"url": "https://wpackagist.org"
+			"url": "https://wpackagist.org",
+      "only": [
+        "wpackagist-plugin/*"
+      ]
 		},
 		{
 			"type":"composer",
@@ -58,8 +61,10 @@
 		"vlucas/phpdotenv": "^5.5",
 		"wpackagist-plugin/accessibility-checker": "^1.10",
 		"wpackagist-plugin/delete-me": "^3.1",
+		"wpackagist-plugin/log-emails": "^1.4",
 		"wpackagist-plugin/miniorange-oauth-20-server": "^6.0",
 		"wpackagist-plugin/olympus-google-fonts": "^3.6",
+		"wpackagist-plugin/stop-emails": "^1.2",
 		"wpackagist-plugin/svg-support": "^2.5",
 		"wpackagist-plugin/tidio-live-chat": "^6.0",
 		"wpackagist-plugin/top-bar": "^3.0",

--- a/client-mu-plugins/goodbids/composer.lock
+++ b/client-mu-plugins/goodbids/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "73c7f35c06e441373a208dba119d7bb0",
+    "content-hash": "3e65cc061d5ca57061744e3c4d569101",
     "packages": [
         {
             "name": "composer/installers",
@@ -1266,6 +1266,24 @@
             "homepage": "https://wordpress.org/plugins/delete-me/"
         },
         {
+            "name": "wpackagist-plugin/log-emails",
+            "version": "1.4.0",
+            "source": {
+                "type": "svn",
+                "url": "https://plugins.svn.wordpress.org/log-emails/",
+                "reference": "tags/1.4.0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://downloads.wordpress.org/plugin/log-emails.1.4.0.zip"
+            },
+            "require": {
+                "composer/installers": "^1.0 || ^2.0"
+            },
+            "type": "wordpress-plugin",
+            "homepage": "https://wordpress.org/plugins/log-emails/"
+        },
+        {
             "name": "wpackagist-plugin/miniorange-oauth-20-server",
             "version": "6.0.5",
             "source": {
@@ -1300,6 +1318,24 @@
             },
             "type": "wordpress-plugin",
             "homepage": "https://wordpress.org/plugins/olympus-google-fonts/"
+        },
+        {
+            "name": "wpackagist-plugin/stop-emails",
+            "version": "1.2.1",
+            "source": {
+                "type": "svn",
+                "url": "https://plugins.svn.wordpress.org/stop-emails/",
+                "reference": "tags/1.2.1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://downloads.wordpress.org/plugin/stop-emails.1.2.1.zip"
+            },
+            "require": {
+                "composer/installers": "^1.0 || ^2.0"
+            },
+            "type": "wordpress-plugin",
+            "homepage": "https://wordpress.org/plugins/stop-emails/"
         },
         {
             "name": "wpackagist-plugin/svg-support",

--- a/client-mu-plugins/goodbids/src/classes/Core.php
+++ b/client-mu-plugins/goodbids/src/classes/Core.php
@@ -314,13 +314,44 @@ class Core {
 				if ( empty( $local['version'] ) || version_compare( $json['version'], $local['version'], '!=' ) ) {
 					Log::warning( 'Local config file version mismatch.' );
 				}
-				$json = array_merge( $json, $local );
+
+				$json = $this->merge_local_config( $json, $local );
 			}
 		}
 
 		$this->config = $json;
 
 		return true;
+	}
+
+	/**
+	 * Merge local json config with the base json config.
+	 *
+	 * @since 1.0.1
+	 *
+	 * @param array $json
+	 * @param array $local
+	 *
+	 * @return array
+	 */
+	private function merge_local_config( array $json, array $local ): array {
+		$merged = [];
+
+		foreach ( $json as $key => $value ) {
+			$merged[ $key ] = $value;
+
+			if ( empty( $local[ $key] ) ) {
+				continue;
+			}
+
+			if ( is_array( $value ) ) {
+				$merged[ $key ] = array_merge( $value, $local[ $key ] );
+			} else {
+				$merged[ $key ] = $local[ $key ];
+			}
+		}
+
+		return $merged;
 	}
 
 	/**

--- a/docs/local.md
+++ b/docs/local.md
@@ -98,3 +98,19 @@ Set your `phpcs` standard to point to `/Absolute/Path/To/goodbids/.phpcs.xml",`
 ## Local Config Override
 
 You can override the default local config by adding a `client-mu-plugins/goodbids/config.local.json` file. This will allow you to override specific settings without risk of committing to the repository.
+
+Here is a recommended starting point for your local config file:
+
+```json
+{
+  "version": "1.0",
+  "advanced": {
+    "debug-mode": true,
+    "logging": true
+  },
+  "active-plugins": [
+    "log-emails",
+    "stop-emails"
+  ]
+}
+```


### PR DESCRIPTION
# Summary

This PR adds plugins for disabling and debugging (logging) emails locally, with some instructions in the README file on how to configure them to be active only when local.

## Issues

* N/A

## Testing Instructions

1. Update your `config.local.json` to match the one in the README
2. Run `composer install`
3. Confirm the Stop Emails and Log Emails plugins are installed and active locally

## Screenshots

<img width="946" alt="Screenshot 2024-05-02 at 4 34 48 PM" src="https://github.com/Good-Bids/goodbids/assets/122309362/9b18d991-8cb3-41bf-a0ec-b9c050023378">
